### PR TITLE
Add CI tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+on: push
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-22.04, windows-2019]
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - run: pip install -r requirements.txt -r requirements-tests.txt
+      - run: pytest -vv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: pip install -r requirements.txt -r requirements-tests.txt
-      - run: pytest -vv
+      - run: python -m pytest -vv

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pip install -r requirements-tests.txt
 Execute tests:
 
 ```
-pytest -vv
+python -m pytest -vv
 ```
 
 They should output something similar to:


### PR DESCRIPTION
**Description**

This PR adds the test CI workflow to test the implementation on both `Linux (ubuntu-22.04)` and `Windows (windows-2019)`, on 3 different Python versions: `3.10`, `3.11` and `3.12`.

**Main changes**

1. Add CI workflow

**How was the PR tested?**

1. Unit-test are being executed as expected in the workflow.

**Notes**
