### PR TITLE
Add checker status and rule uid

### DIFF
--- a/qc_opendrive/checks/__init__.py
+++ b/qc_opendrive/checks/__init__.py
@@ -1,2 +1,3 @@
 from . import utils as utils
 from . import semantic as semantic
+from . import models as models

--- a/qc_opendrive/checks/models.py
+++ b/qc_opendrive/checks/models.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from lxml import etree
+
+from qc_baselib import Configuration, Result
+
+
+@dataclass
+class RuleInput:
+    root: etree._ElementTree
+    config: Configuration
+    result: Result
+    schema_version: str

--- a/qc_opendrive/checks/models.py
+++ b/qc_opendrive/checks/models.py
@@ -5,7 +5,7 @@ from qc_baselib import Configuration, Result
 
 
 @dataclass
-class RuleInput:
+class CheckerData:
     input_file_xml_root: etree._ElementTree
     config: Configuration
     result: Result

--- a/qc_opendrive/checks/models.py
+++ b/qc_opendrive/checks/models.py
@@ -6,7 +6,7 @@ from qc_baselib import Configuration, Result
 
 @dataclass
 class RuleInput:
-    root: etree._ElementTree
+    input_file_xml_root: etree._ElementTree
     config: Configuration
     result: Result
     schema_version: str

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -47,7 +47,7 @@ def check_rule(rule_input: models.RuleInput) -> None:
         rule_full_name="road.lane.access.no_mix_of_deny_or_allow",
     )
 
-    lanes = utils.get_lanes(root=rule_input.root)
+    lanes = utils.get_lanes(root=rule_input.input_file_xml_root)
 
     lane: etree._Element
     for lane in lanes:
@@ -74,7 +74,7 @@ def check_rule(rule_input: models.RuleInput) -> None:
                             rule_uid=rule_uid,
                         )
 
-                        path = rule_input.root.getpath(access)
+                        path = rule_input.input_file_xml_root.getpath(access)
 
                         previous_rule = s_offset_info.rule
                         current_rule = access_attr["rule"]

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -30,6 +30,15 @@ def check_rule(root: etree._ElementTree, config: Configuration, result: Result) 
     """
     logging.info("Executing road.lane.access.no_mix_of_deny_or_allow check")
 
+    rule_uid = result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting="1.8.0",
+        rule_full_name="road.lane.access.no_mix_of_deny_or_allow",
+    )
+
     lanes = utils.get_lanes(root=root)
 
     lane: etree._Element
@@ -54,6 +63,7 @@ def check_rule(root: etree._ElementTree, config: Configuration, result: Result) 
                             checker_id=semantic_constants.CHECKER_ID,
                             description="At a given s-position, either only deny or only allow values shall be given, not mixed.",
                             level=IssueSeverity.ERROR,
+                            rule_uid=rule_uid,
                         )
 
                         path = root.getpath(access)

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -19,8 +19,13 @@ class SOffsetInfo:
     rule: str
 
 
+RULE_SUPPORTED_SCHEMA_VERSIONS = set(["1.7.0", "1.8.0"])
+
+
 # TODO: Add logic to handle that this rule only applied to xord 1.7 and 1.8
-def check_rule(root: etree._ElementTree, config: Configuration, result: Result) -> None:
+def check_rule(
+    root: etree._ElementTree, config: Configuration, result: Result, schema_version: str
+) -> None:
     """
     Implements a rule to check if there is mixed content on access rules for
     the same sOffset on lanes.
@@ -30,12 +35,16 @@ def check_rule(root: etree._ElementTree, config: Configuration, result: Result) 
     """
     logging.info("Executing road.lane.access.no_mix_of_deny_or_allow check")
 
+    if schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+        logging.info(f"Schema version {schema_version} not supported. Skipping rule.")
+        return
+
     rule_uid = result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=semantic_constants.CHECKER_ID,
         emanating_entity="asam.net",
         standard="xodr",
-        definition_setting="1.8.0",
+        definition_setting=schema_version,
         rule_full_name="road.lane.access.no_mix_of_deny_or_allow",
     )
 

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -8,7 +8,7 @@ from lxml import etree
 from qc_baselib import Configuration, Result, IssueSeverity
 
 from qc_opendrive import constants
-from qc_opendrive.checks import utils
+from qc_opendrive.checks import utils, models
 
 from qc_opendrive.checks.semantic import semantic_constants
 
@@ -22,10 +22,7 @@ class SOffsetInfo:
 RULE_SUPPORTED_SCHEMA_VERSIONS = set(["1.7.0", "1.8.0"])
 
 
-# TODO: Add logic to handle that this rule only applied to xord 1.7 and 1.8
-def check_rule(
-    root: etree._ElementTree, config: Configuration, result: Result, schema_version: str
-) -> None:
+def check_rule(rule_input: models.RuleInput) -> None:
     """
     Implements a rule to check if there is mixed content on access rules for
     the same sOffset on lanes.
@@ -35,20 +32,22 @@ def check_rule(
     """
     logging.info("Executing road.lane.access.no_mix_of_deny_or_allow check")
 
-    if schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
-        logging.info(f"Schema version {schema_version} not supported. Skipping rule.")
+    if rule_input.schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+        logging.info(
+            f"Schema version {rule_input.schema_version} not supported. Skipping rule."
+        )
         return
 
-    rule_uid = result.register_rule(
+    rule_uid = rule_input.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=semantic_constants.CHECKER_ID,
         emanating_entity="asam.net",
         standard="xodr",
-        definition_setting=schema_version,
+        definition_setting=rule_input.schema_version,
         rule_full_name="road.lane.access.no_mix_of_deny_or_allow",
     )
 
-    lanes = utils.get_lanes(root=root)
+    lanes = utils.get_lanes(root=rule_input.root)
 
     lane: etree._Element
     for lane in lanes:
@@ -67,7 +66,7 @@ def check_rule(
                         abs(s_offset_info.s_offset - s_offset) <= 1e-6
                         and rule != s_offset_info.rule
                     ):
-                        issue_id = result.register_issue(
+                        issue_id = rule_input.result.register_issue(
                             checker_bundle_name=constants.BUNDLE_NAME,
                             checker_id=semantic_constants.CHECKER_ID,
                             description="At a given s-position, either only deny or only allow values shall be given, not mixed.",
@@ -75,12 +74,12 @@ def check_rule(
                             rule_uid=rule_uid,
                         )
 
-                        path = root.getpath(access)
+                        path = rule_input.root.getpath(access)
 
                         previous_rule = s_offset_info.rule
                         current_rule = access_attr["rule"]
 
-                        result.add_xml_location(
+                        rule_input.result.add_xml_location(
                             checker_bundle_name=constants.BUNDLE_NAME,
                             checker_id=semantic_constants.CHECKER_ID,
                             issue_id=issue_id,

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -93,7 +93,7 @@ def check_rule(rule_input: models.RuleInput) -> None:
         rule_full_name="road.lane.level.true.one_side",
     )
 
-    lane_sections = utils.get_lane_sections(rule_input.root)
+    lane_sections = utils.get_lane_sections(rule_input.input_file_xml_root)
 
     # Sort by s attribute to guarantee order
     sorted_lane_sections = sorted(
@@ -122,7 +122,10 @@ def check_rule(rule_input: models.RuleInput) -> None:
         )
 
         _check_true_level_on_side(
-            rule_input.root, sorted_left_lane, rule_input.result, rule_uid
+            rule_input.input_file_xml_root,
+            sorted_left_lane,
+            rule_input.result,
+            rule_uid,
         )
 
         # sort by lane abs(id) to guarantee order while checking level
@@ -132,7 +135,10 @@ def check_rule(rule_input: models.RuleInput) -> None:
         )
 
         _check_true_level_on_side(
-            rule_input.root, sorted_right_lane, rule_input.result, rule_uid
+            rule_input.input_file_xml_root,
+            sorted_right_lane,
+            rule_input.result,
+            rule_uid,
         )
 
         # check for lane level changing in between consecutive lane sections

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -10,6 +10,8 @@ from qc_opendrive import constants
 from qc_opendrive.checks import utils
 from qc_opendrive.checks.semantic import semantic_constants
 
+RULE_SUPPORTED_SCHEMA_VERSIONS = set(["1.7.0", "1.8.0"])
+
 
 def _check_true_level_on_side(
     root: etree._ElementTree,
@@ -66,7 +68,9 @@ def _check_level_change_between_lane_sections(
     return
 
 
-def check_rule(root: etree._ElementTree, config: Configuration, result: Result) -> None:
+def check_rule(
+    root: etree._ElementTree, config: Configuration, result: Result, schema_version: str
+) -> None:
     """
     Implements a rule to check if there is any @Level=False after true until
     the lane border.
@@ -75,6 +79,10 @@ def check_rule(root: etree._ElementTree, config: Configuration, result: Result) 
         - https://github.com/asam-ev/qc-opendrive/issues/2
     """
     logging.info("Executing road.lane.level.true.one_side check")
+
+    if schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+        logging.info(f"Schema version {schema_version} not supported. Skipping rule.")
+        return
 
     rule_uid = result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -68,7 +68,7 @@ def _check_level_change_between_lane_sections(
     return
 
 
-def check_rule(rule_input: models.RuleInput) -> None:
+def check_rule(checker_data: models.CheckerData) -> None:
     """
     Implements a rule to check if there is any @Level=False after true until
     the lane border.
@@ -78,22 +78,22 @@ def check_rule(rule_input: models.RuleInput) -> None:
     """
     logging.info("Executing road.lane.level.true.one_side check")
 
-    if rule_input.schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+    if checker_data.schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
         logging.info(
-            f"Schema version {rule_input.schema_version} not supported. Skipping rule."
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
         )
         return
 
-    rule_uid = rule_input.result.register_rule(
+    rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=semantic_constants.CHECKER_ID,
         emanating_entity="asam.net",
         standard="xodr",
-        definition_setting=rule_input.schema_version,
+        definition_setting=checker_data.schema_version,
         rule_full_name="road.lane.level.true.one_side",
     )
 
-    lane_sections = utils.get_lane_sections(rule_input.input_file_xml_root)
+    lane_sections = utils.get_lane_sections(checker_data.input_file_xml_root)
 
     # Sort by s attribute to guarantee order
     sorted_lane_sections = sorted(
@@ -122,9 +122,9 @@ def check_rule(rule_input: models.RuleInput) -> None:
         )
 
         _check_true_level_on_side(
-            rule_input.input_file_xml_root,
+            checker_data.input_file_xml_root,
             sorted_left_lane,
-            rule_input.result,
+            checker_data.result,
             rule_uid,
         )
 
@@ -135,9 +135,9 @@ def check_rule(rule_input: models.RuleInput) -> None:
         )
 
         _check_true_level_on_side(
-            rule_input.input_file_xml_root,
+            checker_data.input_file_xml_root,
             sorted_right_lane,
-            rule_input.result,
+            checker_data.result,
             rule_uid,
         )
 

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -5,6 +5,7 @@ from lxml import etree
 from qc_baselib import Configuration, Result, StatusType
 
 from qc_opendrive import constants
+from qc_opendrive.checks import utils
 
 from qc_opendrive.checks.semantic import (
     semantic_constants,
@@ -25,13 +26,15 @@ def run_checks(config: Configuration, result: Result) -> None:
         summary="",
     )
 
+    odr_schema_version = utils.get_standard_schema_version(root)
+
     rule_list = [
         road_lane_level_true_one_side.check_rule,
         road_lane_access_no_mix_of_deny_or_allow.check_rule,
     ]
 
     for rule in rule_list:
-        rule(root=root, config=config, result=result)
+        rule(root=root, config=config, result=result, schema_version=odr_schema_version)
 
     logging.info(
         f"Issues found - {result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=semantic_constants.CHECKER_ID)}"

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -33,7 +33,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_lane_access_no_mix_of_deny_or_allow.check_rule,
     ]
 
-    rule_input = models.RuleInput(
+    checker_data = models.CheckerData(
         input_file_xml_root=root,
         config=config,
         result=result,
@@ -41,7 +41,7 @@ def run_checks(config: Configuration, result: Result) -> None:
     )
 
     for rule in rule_list:
-        rule(rule_input=rule_input)
+        rule(checker_data=checker_data)
 
     logging.info(
         f"Issues found - {result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=semantic_constants.CHECKER_ID)}"

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -5,7 +5,7 @@ from lxml import etree
 from qc_baselib import Configuration, Result, StatusType
 
 from qc_opendrive import constants
-from qc_opendrive.checks import utils
+from qc_opendrive.checks import utils, models
 
 from qc_opendrive.checks.semantic import (
     semantic_constants,
@@ -33,8 +33,12 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_lane_access_no_mix_of_deny_or_allow.check_rule,
     ]
 
+    rule_input = models.RuleInput(
+        root=root, config=config, result=result, schema_version=odr_schema_version
+    )
+
     for rule in rule_list:
-        rule(root=root, config=config, result=result, schema_version=odr_schema_version)
+        rule(rule_input=rule_input)
 
     logging.info(
         f"Issues found - {result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=semantic_constants.CHECKER_ID)}"

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -2,7 +2,7 @@ import logging
 
 from lxml import etree
 
-from qc_baselib import Configuration, Result
+from qc_baselib import Configuration, Result, StatusType
 
 from qc_opendrive import constants
 
@@ -35,4 +35,11 @@ def run_checks(config: Configuration, result: Result) -> None:
 
     logging.info(
         f"Issues found - {result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=semantic_constants.CHECKER_ID)}"
+    )
+
+    # TODO: Add logic to deal with error or to skip it
+    result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        status=StatusType.COMPLETED,
     )

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -34,7 +34,10 @@ def run_checks(config: Configuration, result: Result) -> None:
     ]
 
     rule_input = models.RuleInput(
-        root=root, config=config, result=result, schema_version=odr_schema_version
+        input_file_xml_root=root,
+        config=config,
+        result=result,
+        schema_version=odr_schema_version,
     )
 
     for rule in rule_list:

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -23,3 +23,10 @@ def get_lane_sections(root: etree._ElementTree) -> List[etree._ElementTree]:
 
 def xml_string_to_bool(value: str):
     return value.lower() in ("true",)
+
+
+def get_standard_schema_version(root: etree._ElementTree) -> str:
+    header = root.find("header")
+    header_attrib = header.attrib
+    version = f"{header_attrib['revMajor']}.{header_attrib['revMinor']}.0"
+    return version


### PR DESCRIPTION
**Description**

This PR updates the implementation to match the latest version from the base library.

**Main changes**

1. Add rule uid to road_lane_access_no_mix_of_deny_or_allow
2. Add rule uid to road_lane_level_true_one_side
3. Add checker status to semantic checker

**How was the PR tested?**

1. Unit-test were updated to test the new implementation. All is working as expected.

**Notes**
- We still need to check how to handle the different standard versions.
- There is a `TODO` comment added to decide on the flow of `SKIP` and `ERROR` status for checkers on this bundle.