### PR TITLE
Update rule execution verification

### DIFF
--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -43,7 +43,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
         checker_id=semantic_constants.CHECKER_ID,
         emanating_entity="asam.net",
         standard="xodr",
-        definition_setting=checker_data.schema_version,
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
         rule_full_name="road.lane.access.no_mix_of_deny_or_allow",
     )
 

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -19,7 +19,7 @@ class SOffsetInfo:
     rule: str
 
 
-RULE_SUPPORTED_SCHEMA_VERSIONS = set(["1.7.0", "1.8.0"])
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.7.0"
 
 
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -32,7 +32,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing road.lane.access.no_mix_of_deny_or_allow check")
 
-    if checker_data.schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
         logging.info(
             f"Schema version {checker_data.schema_version} not supported. Skipping rule."
         )

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -11,7 +11,7 @@ from qc_opendrive import constants
 from qc_opendrive.checks import utils, models
 from qc_opendrive.checks.semantic import semantic_constants
 
-RULE_SUPPORTED_SCHEMA_VERSIONS = set(["1.7.0", "1.8.0"])
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.7.0"
 
 
 def _check_true_level_on_side(
@@ -159,7 +159,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing road.lane.level.true.one_side check")
 
-    if checker_data.schema_version not in RULE_SUPPORTED_SCHEMA_VERSIONS:
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
         logging.info(
             f"Schema version {checker_data.schema_version} not supported. Skipping rule."
         )

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -170,7 +170,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
         checker_id=semantic_constants.CHECKER_ID,
         emanating_entity="asam.net",
         standard="xodr",
-        definition_setting=checker_data.schema_version,
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
         rule_full_name="road.lane.level.true.one_side",
     )
 

--- a/tests/data/road_lane_access_no_mix_of_deny_or_allow/road_lane_access_no_mix_of_deny_or_allow_17_invalid_older_schema_version.xodr
+++ b/tests/data/road_lane_access_no_mix_of_deny_or_allow/road_lane_access_no_mix_of_deny_or_allow_17_invalid_older_schema_version.xodr
@@ -1,0 +1,44 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="0" name="" version="1.00" date="Tue Jan 24 12:23:01 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+    </header>
+  <road name="A" length="100.0" id="1" junction="-1" rule="RHT">
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
+        <line/>
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="driving" level="false">
+            <link>
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.7000000000000002e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <access sOffset="1.000" rule="allow" restriction="bus"/>
+            <access sOffset="1.0000015" rule="deny" restriction="bicycle"/>
+            <access sOffset="1.0000008999999999" rule="allow" restriction="truck"/> <!-- issue: mix of allow and deny on same sOffset not allowed -->
+            <access sOffset="1.0000004000000000" rule="deny" restriction="truck"/> <!-- issue: mix of allow and deny on same sOffset not allowed -->
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <link>
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.7000000000000002e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+          <lane id="1" type="driving" level="false">
+            <link>
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.7000000000000002e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+        </left>
+        <center>
+          <lane id="0" type="driving" >
+          </lane>
+        </center>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>

--- a/tests/data/road_lane_level_true_one_side/road_lane_level_true_one_side_invalid_older_schema_version.xodr
+++ b/tests/data/road_lane_level_true_one_side/road_lane_level_true_one_side_invalid_older_schema_version.xodr
@@ -1,0 +1,74 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="0" name="" version="1.00" date="Wed Aug  2 09:16:10 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+    </header>
+  <road name="" length="1.0000000000000000e+02" id="1" junction="-1" rule="RHT">
+    <link>
+    </link>
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="1.1970260013222610e+02" y="9.1508118250189384e+01" hdg="5.1105731189804682e-01" length="1.0000000000000000e+02">
+        <line/>
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+    </elevationProfile>
+    <lateralProfile>
+      <crossSectionSurface>
+        <surfaceStrips>
+          <strip id="1">
+            <linear>
+              <coefficients s="0.0" a="-0.1"/>
+            </linear>
+          </strip>
+          <strip id="-1">
+           <linear>
+              <coefficients s="0.0" a="0.15"/>
+            </linear>
+          </strip>
+        </surfaceStrips>
+      </crossSectionSurface>
+    </lateralProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk" level="false"> <!-- issue: level should be set to true because lane 2 is already true  -->
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+          <lane id="2" type="border" level="true">
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+          <lane id="-2" type="border" level="true">
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+          <lane id="-3" type="sidewalk" level="false"> <!-- issue: level should be set to true because lane -2 is already true  -->
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <objects>
+    </objects>
+    <signals>
+    </signals>
+    <surface>
+    </surface>
+  </road>
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -96,6 +96,7 @@ def cleanup_files():
         ("17_valid", 0, []),
         ("18_invalid", 1, ["/OpenDRIVE/road/lanes/laneSection/left/lane[1]/access[2]"]),
         ("18_valid", 0, []),
+        ("17_invalid_older_schema_version", 0, []),
     ],
 )
 def test_road_lane_access_no_mix_of_deny_or_allow_examples(
@@ -164,6 +165,7 @@ def test_road_lane_access_no_mix_of_deny_or_allow_close_match(
             ],
             [IssueSeverity.ERROR, IssueSeverity.ERROR],
         ),
+        ("invalid_older_schema_version", 0, [], []),
     ],
 )
 def test_road_lane_true_level_one_side(


### PR DESCRIPTION
**Description**

This PR updates the rule execution verification that evaluates if a rule should execute in the current file given its schema. Now, it supports any schema that has a schema version greater or equal to an initial support schema version.

**Main changes**

1. Update rule execution verification to match any schema version higher than initial supported one
2. Update rule uid registration to used fixed schema
3. Add tests to guarantee rules do not execute when schema version is lower

**How was the PR tested?**

1. Unit-test are passing for the new added functionality.

**Notes**
- None.