### PR TITLE
Add check for inter-road and junction lane levels

### DIFF
--- a/qc_opendrive/checks/models.py
+++ b/qc_opendrive/checks/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from lxml import etree
 
 from qc_baselib import Configuration, Result
@@ -10,3 +11,19 @@ class CheckerData:
     config: Configuration
     result: Result
     schema_version: str
+
+
+class LinkageTag(str, Enum):
+    PREDECESSOR = "predecessor"
+    SUCCESSOR = "successor"
+
+
+class ContactPoint(str, Enum):
+    START = "start"
+    END = "end"
+
+
+@dataclass
+class RoadLinkage:
+    id: int
+    contact_point: ContactPoint

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -294,8 +294,8 @@ def _check_level_among_junctions(
     road_id_map: Dict[int, etree._ElementTree],
     rule_uid: str,
 ) -> None:
-    for junction in checker_data.input_file_xml_root.iter("junction"):
-        for connection in junction.iter("connection"):
+    for junction in utils.get_junctions(checker_data.input_file_xml_root):
+        for connection in utils.get_connections_from_junction(junction):
             connection_road_id = connection.get("connectingRoad")
             incoming_road_id = connection.get("incomingRoad")
             connection_road = road_id_map.get(int(connection_road_id))
@@ -323,7 +323,7 @@ def _check_level_among_junctions(
             else:
                 continue
 
-            for lane_link in connection.iter("laneLink"):
+            for lane_link in utils.get_lane_links_from_connection(connection):
                 incoming_lane_id = lane_link.get("from")
                 connection_lane_id = lane_link.get("to")
 

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import logging
 
 from typing import Union, List, Dict, Set
@@ -33,7 +34,6 @@ def _check_true_level_on_side(
         lane_attrib = lane.attrib
 
         if "level" in lane_attrib:
-
             lane_level = utils.xml_string_to_bool(lane_attrib["level"])
 
             if lane_level == True:
@@ -60,39 +60,32 @@ def _check_true_level_on_side(
                 )
 
 
-class LinkageTag(str, Enum):
-    PREDECESSOR = "predecessor"
-    SUCCESSOR = "successor"
-
-
-def _get_lane_level(lanes: List[etree._Element], lane_id: int) -> Union[str, None]:
-    return next(
-        (lane.attrib["level"] for lane in lanes if int(lane.attrib["id"]) == lane_id),
-        None,
-    )
-
-
 def _get_linkage_level_warnings(
     root: etree._ElementTree,
-    current_lanes: List[etree._Element],
-    target_lanes: List[etree._Element],
-    linkage_tag: LinkageTag,
+    current_lane_section: etree._ElementTree,
+    target_lane_section: etree._ElementTree,
+    linkage_tag: models.LinkageTag,
 ):
     warnings: Set[str] = set()
 
-    for lane in current_lanes:
-        lane_id = int(lane.attrib["id"])
-        lane_level = lane.attrib["level"]
+    for lane in utils.get_left_and_right_lanes_from_lane_section(current_lane_section):
+        lane_level = utils.get_lane_level_from_lane(lane)
 
-        links: Union[None, List[etree._Element]] = lane.findall("link")
-        for link in links:
-            linkages: List[etree._Element] = link.findall(linkage_tag)
+        for link in lane.findall("link"):
+            for linkage in link.findall(linkage_tag):
+                linkage_id = linkage.get("id")
+                if linkage_id is None:
+                    continue
+                linkage_id = int(linkage_id)
+                linkage_lane = utils.get_lane_from_lane_section(
+                    target_lane_section, linkage_id
+                )
+                if linkage_lane is None:
+                    continue
 
-            for linkage in linkages:
-                linkage_id = int(linkage.attrib["id"])
-                linkage_level = _get_lane_level(target_lanes, linkage_id)
+                linkage_level = utils.get_lane_level_from_lane(linkage_lane)
 
-                if linkage_level is not None and linkage_level != lane_level:
+                if linkage_level != lane_level:
                     warnings.add(root.getpath(lane))
 
     return warnings
@@ -100,8 +93,8 @@ def _get_linkage_level_warnings(
 
 def _check_level_change_between_lane_sections(
     root: etree._ElementTree,
-    current_lanes: List[etree._Element],
-    previous_lanes: List[etree._Element],
+    current_lane_section: etree._ElementTree,
+    previous_lane_section: etree._ElementTree,
     result: Result,
     rule_uid: str,
 ) -> None:
@@ -118,15 +111,15 @@ def _check_level_change_between_lane_sections(
 
     predecessor_warnings = _get_linkage_level_warnings(
         root=root,
-        current_lanes=current_lanes,
-        target_lanes=previous_lanes,
-        linkage_tag=LinkageTag.PREDECESSOR,
+        current_lane_section=current_lane_section,
+        target_lane_section=previous_lane_section,
+        linkage_tag=models.LinkageTag.PREDECESSOR,
     )
     successor_warnings = _get_linkage_level_warnings(
         root=root,
-        current_lanes=previous_lanes,
-        target_lanes=current_lanes,
-        linkage_tag=LinkageTag.SUCCESSOR,
+        current_lane_section=previous_lane_section,
+        target_lane_section=current_lane_section,
+        linkage_tag=models.LinkageTag.SUCCESSOR,
     )
 
     warnings = predecessor_warnings | successor_warnings
@@ -136,7 +129,7 @@ def _check_level_change_between_lane_sections(
         issue_id = result.register_issue(
             checker_bundle_name=constants.BUNDLE_NAME,
             checker_id=semantic_constants.CHECKER_ID,
-            description="",
+            description="Lane levels are not the same in two consecutive lane sections",
             level=IssueSeverity.WARNING,
             rule_uid=rule_uid,
         )
@@ -149,56 +142,125 @@ def _check_level_change_between_lane_sections(
         )
 
 
-def check_rule(checker_data: models.CheckerData) -> None:
-    """
-    Implements a rule to check if there is any @Level=False after true until
-    the lane border.
+def _check_level_change_linkage_roads(
+    linkage_tag: models.LinkageTag,
+    road: etree._ElementTree,
+    road_id_map: Dict[int, etree._ElementTree],
+    result: Result,
+    rule_uid: str,
+    root: etree._ElementTree,
+) -> None:
+    if linkage_tag == models.LinkageTag.PREDECESSOR:
+        current_lane_section = utils.get_first_lane_section(road)
+    else:
+        current_lane_section = utils.get_last_lane_section(road)
 
-    More info at
-        - https://github.com/asam-ev/qc-opendrive/issues/2
-    """
-    logging.info("Executing road.lane.level.true.one_side check")
+    all_lanes = utils.get_left_and_right_lanes_from_lane_section(current_lane_section)
 
-    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
-        logging.info(
-            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
-        )
+    linkage = utils.get_road_linkage(road, linkage_tag)
+    if linkage is None:
         return
 
-    rule_uid = checker_data.result.register_rule(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=semantic_constants.CHECKER_ID,
-        emanating_entity="asam.net",
-        standard="xodr",
-        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
-        rule_full_name="road.lane.level.true.one_side",
-    )
+    linkage_road = road_id_map.get(linkage.id)
+    if linkage_road is None:
+        return
 
+    other_lane_section = None
+    if linkage.contact_point == models.ContactPoint.START:
+        other_lane_section = utils.get_first_lane_section(linkage_road)
+    elif linkage.contact_point == models.ContactPoint.END:
+        other_lane_section = utils.get_last_lane_section(linkage_road)
+
+    if other_lane_section is None:
+        return
+
+    for lane in all_lanes:
+        lane_level = utils.get_lane_level_from_lane(lane)
+
+        if linkage_tag == models.LinkageTag.PREDECESSOR:
+            linkage_lane_ids = utils.get_predecessor_lane_ids(lane)
+        else:
+            linkage_lane_ids = utils.get_successor_lane_ids(lane)
+
+        for lane_id in linkage_lane_ids:
+            other_lane = utils.get_lane_from_lane_section(other_lane_section, lane_id)
+            if other_lane is None:
+                continue
+
+            other_lane_level = utils.get_lane_level_from_lane(other_lane)
+            if other_lane_level is not None and other_lane_level != lane_level:
+                issue_id = result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description="Lane levels are not the same between two connected roads.",
+                    level=IssueSeverity.WARNING,
+                    rule_uid=rule_uid,
+                )
+
+                result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=root.getpath(lane),
+                    description="",
+                )
+
+
+def _check_level_among_lane_sections(
+    checker_data: models.CheckerData,
+    rule_uid: str,
+) -> None:
     roads = utils.get_roads(checker_data.input_file_xml_root)
+    for road in roads:
+        lane_sections = utils.get_lane_sections(road)
+        if len(lane_sections) >= 2:
+            # check for lane level changing in between consecutive lane sections
+            for i in range(1, len(lane_sections)):
+                _check_level_change_between_lane_sections(
+                    root=checker_data.input_file_xml_root,
+                    current_lane_section=lane_sections[i],
+                    previous_lane_section=lane_sections[i - 1],
+                    result=checker_data.result,
+                    rule_uid=rule_uid,
+                )
 
+
+def _check_level_among_roads(
+    checker_data: models.CheckerData,
+    road_id_map: Dict[int, etree._ElementTree],
+    rule_uid: str,
+) -> None:
+    roads = utils.get_roads(checker_data.input_file_xml_root)
+    for road in roads:
+        _check_level_change_linkage_roads(
+            linkage_tag=models.LinkageTag.PREDECESSOR,
+            road=road,
+            road_id_map=road_id_map,
+            result=checker_data.result,
+            rule_uid=rule_uid,
+            root=checker_data.input_file_xml_root,
+        )
+        _check_level_change_linkage_roads(
+            linkage_tag=models.LinkageTag.SUCCESSOR,
+            road=road,
+            road_id_map=road_id_map,
+            result=checker_data.result,
+            rule_uid=rule_uid,
+            root=checker_data.input_file_xml_root,
+        )
+
+
+def _check_level_in_lane_section(
+    checker_data: models.CheckerData,
+    rule_uid: str,
+) -> None:
+    roads = utils.get_roads(checker_data.input_file_xml_root)
     for road in roads:
         lane_sections = utils.get_lane_sections(road)
 
-        # Sort by s attribute to guarantee order
-        sorted_lane_sections = sorted(
-            lane_sections, key=lambda section: float(section.attrib["s"])
-        )
-
-        previous_left_lane: List[etree._Element] = []
-        previous_right_lane: List[etree._Element] = []
-
-        for lane_section in sorted_lane_sections:
-            left_lane = lane_section.find("left")
-            if left_lane is not None:
-                left_lanes_list = left_lane.findall("lane")
-            else:
-                left_lanes_list = []
-
-            right_lane = lane_section.find("right")
-            if right_lane is not None:
-                right_lanes_list = right_lane.findall("lane")
-            else:
-                right_lanes_list = []
+        for lane_section in lane_sections:
+            left_lanes_list = utils.get_left_lanes_from_lane_section(lane_section)
+            right_lanes_list = utils.get_right_lanes_from_lane_section(lane_section)
 
             # sort by lane id to guarantee order while checking level
             # left ids goes monotonic increasing from 1
@@ -226,23 +288,123 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 rule_uid,
             )
 
-            # check for lane level changing in between consecutive lane sections
-            _check_level_change_between_lane_sections(
-                root=checker_data.input_file_xml_root,
-                current_lanes=sorted_left_lane,
-                previous_lanes=previous_left_lane,
-                result=checker_data.result,
-                rule_uid=rule_uid,
-            )
-            _check_level_change_between_lane_sections(
-                root=checker_data.input_file_xml_root,
-                current_lanes=sorted_right_lane,
-                previous_lanes=previous_right_lane,
-                result=checker_data.result,
-                rule_uid=rule_uid,
-            )
 
-            previous_left_lane = sorted_left_lane
-            previous_right_lane = sorted_right_lane
+def _check_level_among_junctions(
+    checker_data: models.CheckerData,
+    road_id_map: Dict[int, etree._ElementTree],
+    rule_uid: str,
+) -> None:
+    for junction in checker_data.input_file_xml_root.iter("junction"):
+        for connection in junction.iter("connection"):
+            connection_road_id = connection.get("connectingRoad")
+            incoming_road_id = connection.get("incomingRoad")
+            connection_road = road_id_map.get(int(connection_road_id))
+            incoming_road = road_id_map.get(int(incoming_road_id))
 
-    # TODO: Add inter road lane level validation
+            if connection_road is None or incoming_road is None:
+                continue
+
+            connection_lane_sections = utils.get_lane_sections(connection_road)
+            incoming_lane_sections = utils.get_lane_sections(incoming_road)
+
+            if len(connection_lane_sections) == 0 or len(incoming_lane_sections) == 0:
+                continue
+
+            contact_point = connection.get("contactPoint")
+            incoming_lane_section = None
+            connection_lane_section = None
+            if contact_point == "start":
+                incoming_lane_section = incoming_lane_sections[-1]
+                connection_lane_section = connection_lane_sections[0]
+            elif contact_point == "end":
+                # Case outgoing lane
+                incoming_lane_section = incoming_lane_sections[0]
+                connection_lane_section = connection_lane_sections[-1]
+            else:
+                continue
+
+            for lane_link in connection.iter("laneLink"):
+                incoming_lane_id = lane_link.get("from")
+                connection_lane_id = lane_link.get("to")
+
+                if incoming_lane_id is None or connection_lane_id is None:
+                    continue
+
+                incoming_lane = utils.get_lane_from_lane_section(
+                    incoming_lane_section, int(incoming_lane_id)
+                )
+                connection_lane = utils.get_lane_from_lane_section(
+                    connection_lane_section, int(connection_lane_id)
+                )
+
+                if incoming_lane is None or connection_lane is None:
+                    continue
+
+                incoming_level = utils.get_lane_level_from_lane(incoming_lane)
+                connection_level = utils.get_lane_level_from_lane(connection_lane)
+
+                if incoming_level != connection_level:
+                    issue_id = checker_data.result.register_issue(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=semantic_constants.CHECKER_ID,
+                        description="Lane levels are not the same between incoming road and junction.",
+                        level=IssueSeverity.WARNING,
+                        rule_uid=rule_uid,
+                    )
+
+                    checker_data.result.add_xml_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=semantic_constants.CHECKER_ID,
+                        issue_id=issue_id,
+                        xpath=checker_data.input_file_xml_root.getpath(incoming_lane),
+                        description="",
+                    )
+
+                    issue_id = checker_data.result.register_issue(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=semantic_constants.CHECKER_ID,
+                        description="Lane levels are not the same between junction and incoming road.",
+                        level=IssueSeverity.WARNING,
+                        rule_uid=rule_uid,
+                    )
+
+                    checker_data.result.add_xml_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=semantic_constants.CHECKER_ID,
+                        issue_id=issue_id,
+                        xpath=checker_data.input_file_xml_root.getpath(connection_lane),
+                        description="",
+                    )
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements a rule to check if there is any @Level=False after true until
+    the lane border.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/2
+    """
+    logging.info("Executing road.lane.level.true.one_side check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="road.lane.level_true_one_side",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    road_id_map = utils.get_road_id_map(checker_data.input_file_xml_root)
+
+    _check_level_in_lane_section(checker_data, rule_uid)
+    _check_level_among_lane_sections(checker_data, rule_uid)
+    _check_level_among_roads(checker_data, road_id_map, rule_uid)
+    _check_level_among_junctions(checker_data, road_id_map, rule_uid)

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -192,3 +192,19 @@ def get_lane_from_lane_section(
 
 def get_lane_level_from_lane(lane: etree._ElementTree) -> bool:
     return lane.get("level") == "true"
+
+
+def get_junctions(root: etree._ElementTree) -> List[etree._ElementTree]:
+    return list(root.iter("junction"))
+
+
+def get_lane_links_from_connection(
+    connection: etree._ElementTree,
+) -> List[etree._ElementTree]:
+    return list(connection.iter("laneLink"))
+
+
+def get_connections_from_junction(
+    junction: etree._ElementTree,
+) -> List[etree._ElementTree]:
+    return list(junction.iter("connection"))

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import List, Dict, Union
 
 from lxml import etree
+from qc_opendrive.checks import models
 
 
 def get_lanes(root: etree._ElementTree) -> List[etree._ElementTree]:
@@ -12,13 +13,29 @@ def get_lanes(root: etree._ElementTree) -> List[etree._ElementTree]:
     return lanes
 
 
-def get_lane_sections(root: etree._ElementTree) -> List[etree._ElementTree]:
+def get_lane_sections(road: etree._ElementTree) -> List[etree._ElementTree]:
     lane_sections = []
 
-    for lane_section in root.iter("laneSection"):
+    for lane_section in road.iter("laneSection"):
         lane_sections.append(lane_section)
 
     return lane_sections
+
+
+def get_last_lane_section(road: etree._ElementTree) -> Union[None, etree._ElementTree]:
+    lane_sections = get_lane_sections(road)
+    if len(lane_sections) > 0:
+        return lane_sections[-1]
+    else:
+        return None
+
+
+def get_first_lane_section(road: etree._ElementTree) -> Union[None, etree._ElementTree]:
+    lane_sections = get_lane_sections(road)
+    if len(lane_sections) > 0:
+        return lane_sections[0]
+    else:
+        return None
 
 
 def get_roads(root: etree._ElementTree) -> List[etree._ElementTree]:
@@ -30,6 +47,73 @@ def get_roads(root: etree._ElementTree) -> List[etree._ElementTree]:
     return roads
 
 
+def get_road_id_map(root: etree._ElementTree) -> Dict[int, etree._ElementTree]:
+    """
+    Returns a dictionary where keys are the road IDs and values are the road.
+    Roads without a valid ID are not included in the dictionary.
+    If there are multiple roads with the same ID, a random road will be included in the dictionary
+    """
+
+    road_id_map = dict()
+
+    for road in root.iter("road"):
+        road_id = road.get("id")
+        if road_id is not None:
+            road_id_map[int(road_id)] = road
+
+    return road_id_map
+
+
+def get_junction_id_map(root: etree._ElementTree) -> Dict[int, etree._ElementTree]:
+    """
+    Returns a dictionary where keys are the junction IDs and values are the junction.
+    Junctions without a valid ID are not included in the dictionary.
+    If there are multiple junctions with the same ID, a random junction will be included in the dictionary
+    """
+
+    junction_id_map = dict()
+
+    for junction in root.iter("junction"):
+        junction_id = junction.get("id")
+        if junction_id is not None:
+            junction_id_map[int(junction_id)] = junction
+
+    return junction_id_map
+
+
+def get_left_lanes_from_lane_section(
+    lane_section: etree._ElementTree,
+) -> List[etree._Element]:
+    left_lane = lane_section.find("left")
+    if left_lane is not None:
+        left_lanes_list = left_lane.findall("lane")
+    else:
+        left_lanes_list = []
+
+    return left_lanes_list
+
+
+def get_right_lanes_from_lane_section(
+    lane_section: etree._ElementTree,
+) -> List[etree._Element]:
+    right_lane = lane_section.find("right")
+    if right_lane is not None:
+        right_lanes_list = right_lane.findall("lane")
+    else:
+        right_lanes_list = []
+
+    return right_lanes_list
+
+
+def get_left_and_right_lanes_from_lane_section(
+    lane_section: etree._ElementTree,
+) -> List[etree._Element]:
+    left_lanes = get_left_lanes_from_lane_section(lane_section)
+    right_lanes = get_right_lanes_from_lane_section(lane_section)
+
+    return left_lanes + right_lanes
+
+
 def xml_string_to_bool(value: str):
     return value.lower() in ("true",)
 
@@ -39,3 +123,72 @@ def get_standard_schema_version(root: etree._ElementTree) -> str:
     header_attrib = header.attrib
     version = f"{header_attrib['revMajor']}.{header_attrib['revMinor']}.0"
     return version
+
+
+def get_road_linkage(
+    road: etree._ElementTree, linkage_tag: models.LinkageTag
+) -> Union[None, models.RoadLinkage]:
+    road_link = road.find("link")
+    if road_link is None:
+        return None
+
+    linkage = road_link.find(linkage_tag.value)
+
+    if linkage is None:
+        return None
+    elif linkage.get("elementType") == "road":
+        road_id = linkage.get("elementId")
+        contact_point = linkage.get("contactPoint")
+        if road_id is None or contact_point is None:
+            return None
+        else:
+            return models.RoadLinkage(
+                id=int(road_id), contact_point=models.ContactPoint(contact_point)
+            )
+    else:
+        return None
+
+
+def get_predecessor_lane_ids(lane: etree._ElementTree) -> List[int]:
+    links = lane.findall("link")
+
+    predecessors = []
+    for link in links:
+        linkages = link.findall("predecessor")
+        for linkage in linkages:
+            predecessor_id = linkage.get("id")
+            if predecessor_id is not None:
+                predecessors.append(int(predecessor_id))
+
+    return predecessors
+
+
+def get_successor_lane_ids(lane: etree._ElementTree) -> List[int]:
+    links = lane.findall("link")
+
+    successors = []
+    for link in links:
+        linkages = link.findall("successor")
+        for linkage in linkages:
+            successor_id = linkage.get("id")
+            if successor_id is not None:
+                successors.append(int(successor_id))
+
+    return successors
+
+
+def get_lane_from_lane_section(
+    lane_section: etree._ElementTree, lane_id: int
+) -> Union[None, etree._ElementTree]:
+    lanes = get_left_and_right_lanes_from_lane_section(lane_section)
+
+    for lane in lanes:
+        current_id = lane.get("id")
+        if current_id is not None and int(current_id) == lane_id:
+            return lane
+
+    return None
+
+
+def get_lane_level_from_lane(lane: etree._ElementTree) -> bool:
+    return lane.get("level") == "true"

--- a/tests/data/road_lane_level_true_one_side_junction/road_lane_level_true_one_side_junction_invalid_incoming.xodr
+++ b/tests/data/road_lane_level_true_one_side_junction/road_lane_level_true_one_side_junction_invalid_incoming.xodr
@@ -1,0 +1,122 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="8" name="" version="1.00" date="Thu Aug 10 13:44:45 2023"
+        north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+        west="0.0000000000000000e+00">
+    </header>
+    <road name="" length="3.6746837512979852e+01" id="1" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="junction" elementId="1" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town" />
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-5.2650689905591861e+01"
+                y="3.1227305737109661e+00" hdg="3.9525485867501885e-03"
+                length="3.6746837512979852e+01">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00"
+                b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+                            color="standard" width="1.2000000000000000e-01" laneChange="both"
+                            height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01">
+                                <line length="4.0000000000000000e+00" space="8.0000000000000000e+00"
+                                    tOffset="0.0000000000000000e+00"
+                                    sOffset="0.0000000000000000e+00" rule="caution"
+                                    width="1.2000000000000000e-01" />
+                            </type>
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="true">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="3.0000000000000004e+01" id="6" junction="1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town" />
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-1.5904139433551197e+01"
+                y="3.2679738562091503e+00" hdg="3.9525485867501799e-03"
+                length="3.0000000000000004e+01">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00"
+                b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                            <predecessor id="-1" />
+                            <successor id="-1" />
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <junction name="" id="1">
+        <connection id="3" incomingRoad="1" connectingRoad="6" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/tests/data/road_lane_level_true_one_side_junction/road_lane_level_true_one_side_junction_valid.xodr
+++ b/tests/data/road_lane_level_true_one_side_junction/road_lane_level_true_one_side_junction_valid.xodr
@@ -1,0 +1,122 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="8" name="" version="1.00" date="Thu Aug 10 13:44:45 2023"
+        north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+        west="0.0000000000000000e+00">
+    </header>
+    <road name="" length="3.6746837512979852e+01" id="1" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="junction" elementId="1" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town" />
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-5.2650689905591861e+01"
+                y="3.1227305737109661e+00" hdg="3.9525485867501885e-03"
+                length="3.6746837512979852e+01">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00"
+                b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+                            color="standard" width="1.2000000000000000e-01" laneChange="both"
+                            height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01">
+                                <line length="4.0000000000000000e+00" space="8.0000000000000000e+00"
+                                    tOffset="0.0000000000000000e+00"
+                                    sOffset="0.0000000000000000e+00" rule="caution"
+                                    width="1.2000000000000000e-01" />
+                            </type>
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="3.0000000000000004e+01" id="6" junction="1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town" />
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-1.5904139433551197e+01"
+                y="3.2679738562091503e+00" hdg="3.9525485867501799e-03"
+                length="3.0000000000000004e+01">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00"
+                b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                            <predecessor id="-1" />
+                            <successor id="-1" />
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00"
+                            b="0.0000000000000000e+00" c="0.0000000000000000e+00"
+                            d="0.0000000000000000e+00" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <junction name="" id="1">
+        <connection id="3" incomingRoad="1" connectingRoad="6" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/tests/data/road_lane_level_true_one_side_road/road_lane_level_true_one_side_road_invalid.xodr
+++ b/tests/data/road_lane_level_true_one_side_road/road_lane_level_true_one_side_road_invalid.xodr
@@ -1,0 +1,263 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="8" name="" version="1.00" date="Thu Feb 27 11:27:16 2020" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+    </header>
+    <road name="" length="9.0000000000000114e+01" id="18" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="road" elementId="6" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="rural"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="3.4000000000000034e+02" y="9.9999999991009884e+02" hdg="-3.1415926535873062e+00" length="9.0000000000000114e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="8.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="2.5000000000000000e+00" a="8.0000000000000000e+00" b="0.0000000000000000e+00" c="-4.5454545454545455e-04" d="0.0000000000000000e+00"/>
+            <elevation s="5.7500000000000000e+01" a="6.6250000000000000e+00" b="-5.0000000000000003e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="1.7500000000000000e+00" b="0.0000000000000000e+00" c="-2.0999999999999999e-03" d="2.8000000000000000e-05"/>
+            <laneOffset s="5.0000000000000000e+01" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="4" type="none" level="false">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="3" type="border" level="false">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="4.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <width sOffset="3.0000000000000000e+01" a="4.5000000000000000e+00" b="0.0000000000000000e+00" c="-3.3749999999999995e-02" d="1.1249999999999999e-03"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="2.5000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                        <roadMark sOffset="4.0000000000000000e+01" type="none" weight="standard" color="standard" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="restricted" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="-4.2000000000000006e-03" d="5.6000000000000006e-05"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="driving" level="false">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-3" type="border" level="false">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="none" weight="standard" color="standard" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-4" type="none" level="false">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="5.0000000000000000e+01">
+                <left>
+                    <lane id="3" type="none" level="true">
+                        <link>
+                            <predecessor id="4"/>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="border" level="false">
+                        <link>
+                            <predecessor id="3"/>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-2"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <predecessor id="-3"/>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="-3" type="none" level="false">
+                        <link>
+                            <predecessor id="-4"/>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+            <signal s="0.0000000000000000e+00" t="-6.7500000000000000e+00" id="29" name="Sg306Vorfahrtstrasse02" dynamic="no" orientation="+" zOffset="1.7800000131130220e+00" type="306" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.83" width="0.82">
+                <validity fromLane="0" toLane="0"/>
+            </signal>
+            <signal s="5.2000000000000000e+01" t="4.7500000000000000e+00" id="27" name="Sg306Vorfahrtstrasse02" dynamic="no" orientation="-" zOffset="1.7800000131130220e+00" type="306" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.83" width="0.82">
+                <validity fromLane="0" toLane="0"/>
+            </signal>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.5000000000000074e+02" id="6" junction="-1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="18" contactPoint="end" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="rural"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="2.5000000000000023e+02" y="9.9999999990942808e+02" hdg="-3.1415926535873098e+00" length="2.5000000000000074e+02">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="5.0000000000000000e+00" b="-5.0000000000000003e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="2.9444444444444443e+01" a="3.5277777777777777e+00" b="-5.0000000000000003e-02" c="2.2727272727272727e-04" d="0.0000000000000000e+00"/>
+            <elevation s="9.0555555555555557e+01" a="1.3209876543209873e+00" b="-2.2222222222222223e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="9.4444444444444443e+01" a="1.2345679012345676e+00" b="-2.2222222222222223e-02" c="1.0000000000000000e-04" d="0.0000000000000000e+00"/>
+            <elevation s="2.0555555555555554e+02" a="-4.4408920985006262e-16" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="3" type="none" level="false">
+                        <link>
+                            <predecessor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="border" level="false">
+                        <link>
+                            <predecessor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <predecessor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="-3" type="none" level="false">
+                        <link>
+                            <predecessor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+            <signal s="1.0078125000000006e+02" t="6.0000000000000000e+00" id="0" name="Sg440VorwegweiserBaldhamLiStgReM" dynamic="no" orientation="-" zOffset="1.5800000429153442e+00" type="440" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="2.85" width="2.50">
+                <userData code="3" value="0.0000000000000000e+00"/>
+            </signal>
+            <signal s="1.1900000000000000e+02" t="-4.7500000000000000e+00" id="53" name="Sg278EndeHoechst70_03" dynamic="no" orientation="+" zOffset="1.8200000047683718e+00" type="278" country="DE" countryRevision="2013" subtype="57" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.76" width="0.77">
+                <validity fromLane="0" toLane="3"/>
+            </signal>
+            <signal s="1.2000000000000000e+02" t="4.7500000000000000e+00" id="51" name="Sg274Hoechstgeschw70_02" dynamic="no" orientation="-" zOffset="1.8999999880790712e+00" type="274" country="DE" countryRevision="2013" subtype="57" value="7.0000000000000000e+01" unit="km/h" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.61" width="0.61">
+                <validity fromLane="0" toLane="3"/>
+            </signal>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+</OpenDRIVE>

--- a/tests/data/road_lane_level_true_one_side_road/road_lane_level_true_one_side_road_valid.xodr
+++ b/tests/data/road_lane_level_true_one_side_road/road_lane_level_true_one_side_road_valid.xodr
@@ -1,0 +1,263 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="8" name="" version="1.00" date="Thu Feb 27 11:27:16 2020" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+    </header>
+    <road name="" length="9.0000000000000114e+01" id="18" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="road" elementId="6" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="rural"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="3.4000000000000034e+02" y="9.9999999991009884e+02" hdg="-3.1415926535873062e+00" length="9.0000000000000114e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="8.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="2.5000000000000000e+00" a="8.0000000000000000e+00" b="0.0000000000000000e+00" c="-4.5454545454545455e-04" d="0.0000000000000000e+00"/>
+            <elevation s="5.7500000000000000e+01" a="6.6250000000000000e+00" b="-5.0000000000000003e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="1.7500000000000000e+00" b="0.0000000000000000e+00" c="-2.0999999999999999e-03" d="2.8000000000000000e-05"/>
+            <laneOffset s="5.0000000000000000e+01" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="4" type="none" level="false">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="3" type="border" level="false">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="4.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <width sOffset="3.0000000000000000e+01" a="4.5000000000000000e+00" b="0.0000000000000000e+00" c="-3.3749999999999995e-02" d="1.1249999999999999e-03"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="2.5000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                        <roadMark sOffset="4.0000000000000000e+01" type="none" weight="standard" color="standard" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="restricted" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="-4.2000000000000006e-03" d="5.6000000000000006e-05"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="driving" level="false">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-3" type="border" level="false">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="none" weight="standard" color="standard" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-4" type="none" level="false">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="5.0000000000000000e+01">
+                <left>
+                    <lane id="3" type="none" level="false">
+                        <link>
+                            <predecessor id="4"/>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="border" level="false">
+                        <link>
+                            <predecessor id="3"/>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-2"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <predecessor id="-3"/>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="-3" type="none" level="false">
+                        <link>
+                            <predecessor id="-4"/>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+            <signal s="0.0000000000000000e+00" t="-6.7500000000000000e+00" id="29" name="Sg306Vorfahrtstrasse02" dynamic="no" orientation="+" zOffset="1.7800000131130220e+00" type="306" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.83" width="0.82">
+                <validity fromLane="0" toLane="0"/>
+            </signal>
+            <signal s="5.2000000000000000e+01" t="4.7500000000000000e+00" id="27" name="Sg306Vorfahrtstrasse02" dynamic="no" orientation="-" zOffset="1.7800000131130220e+00" type="306" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.83" width="0.82">
+                <validity fromLane="0" toLane="0"/>
+            </signal>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.5000000000000074e+02" id="6" junction="-1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="18" contactPoint="end" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="rural"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="2.5000000000000023e+02" y="9.9999999990942808e+02" hdg="-3.1415926535873098e+00" length="2.5000000000000074e+02">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="5.0000000000000000e+00" b="-5.0000000000000003e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="2.9444444444444443e+01" a="3.5277777777777777e+00" b="-5.0000000000000003e-02" c="2.2727272727272727e-04" d="0.0000000000000000e+00"/>
+            <elevation s="9.0555555555555557e+01" a="1.3209876543209873e+00" b="-2.2222222222222223e-02" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <elevation s="9.4444444444444443e+01" a="1.2345679012345676e+00" b="-2.2222222222222223e-02" c="1.0000000000000000e-04" d="0.0000000000000000e+00"/>
+            <elevation s="2.0555555555555554e+02" a="-4.4408920985006262e-16" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="3" type="none" level="false">
+                        <link>
+                            <predecessor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="2" type="border" level="false">
+                        <link>
+                            <predecessor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <predecessor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="1.5000000000000000e+00" b="-0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                    </lane>
+                    <lane id="-3" type="none" level="false">
+                        <link>
+                            <predecessor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+            <signal s="1.0078125000000006e+02" t="6.0000000000000000e+00" id="0" name="Sg440VorwegweiserBaldhamLiStgReM" dynamic="no" orientation="-" zOffset="1.5800000429153442e+00" type="440" country="DE" countryRevision="2013" subtype="-1" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="2.85" width="2.50">
+                <userData code="3" value="0.0000000000000000e+00"/>
+            </signal>
+            <signal s="1.1900000000000000e+02" t="-4.7500000000000000e+00" id="53" name="Sg278EndeHoechst70_03" dynamic="no" orientation="+" zOffset="1.8200000047683718e+00" type="278" country="DE" countryRevision="2013" subtype="57" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.76" width="0.77">
+                <validity fromLane="0" toLane="3"/>
+            </signal>
+            <signal s="1.2000000000000000e+02" t="4.7500000000000000e+00" id="51" name="Sg274Hoechstgeschw70_02" dynamic="no" orientation="-" zOffset="1.8999999880790712e+00" type="274" country="DE" countryRevision="2013" subtype="57" value="7.0000000000000000e+01" unit="km/h" hOffset="0.0000000000000000e+00" pitch="0.0000000000000000e+00" roll="0.0000000000000000e+00" height="0.61" width="0.61">
+                <validity fromLane="0" toLane="3"/>
+            </signal>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+</OpenDRIVE>

--- a/tests/data/utils/Ex_Bidirectional_Junction.xodr
+++ b/tests/data/utils/Ex_Bidirectional_Junction.xodr
@@ -1,0 +1,310 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="8" name="" version="1.00" date="Thu Aug 10 13:44:45 2023" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+    </header>
+    <road name="" length="3.6746837512979852e+01" id="1" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="junction" elementId="1" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-5.2650689905591861e+01" y="3.1227305737109661e+00" hdg="3.9525485867501885e-03" length="3.6746837512979852e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01">
+                                <line length="4.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="3.0000000000000004e+01" id="6" junction="1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-1.5904139433551197e+01" y="3.2679738562091503e+00" hdg="3.9525485867501799e-03" length="3.0000000000000004e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.0000000000000007e+01" id="2" junction="-1" rule="RHT">
+        <link>
+            <predecessor elementType="junction" elementId="1" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="1.4095626227148930e+01" y="3.3865500050656721e+00" hdg="3.9525485867501643e-03" length="2.0000000000000007e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.1746217945006254e+01" id="3" junction="-1" rule="RHT">
+        <link>
+            <successor elementType="junction" elementId="1" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-4.3890031921279054e+00" y="-3.7082214341375696e+01" hdg="1.4623109477744438e+00" length="2.1746217945006254e+01">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.9103777474795180e+01" id="4" junction="1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="3" contactPoint="end" />
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-2.0344812704984090e+00" y="-1.5463837403402806e+01" hdg="1.4623109477744440e+00" length="6.5884390954806555e+00">
+                <line/>
+            </geometry>
+            <geometry s="6.5884390954806555e+00" x="-1.3211331233005990e+00" y="-8.9141302240132259e+00" hdg="1.4623109477744438e+00" length="3.9265205800922378e+00">
+                <spiral curvStart="-0.0000000000000000e+00" curvEnd="-8.6688281123841415e-02"/>
+            </geometry>
+            <geometry s="1.0514959675572893e+01" x="-6.7624143195316710e-01" y="-5.0460522794912084e+00" hdg="1.2921192878328929e+00" length="1.2896496098532491e+01">
+                <arc curvature="-8.6688281123841415e-02"/>
+            </geometry>
+            <geometry s="2.3411455774105384e+01" x="8.4155855294684851e+00" y="3.1418042699324804e+00" hdg="1.7414420853078427e-01" length="3.9265205800922378e+00">
+                 <spiral curvStart="-8.6688281123841415e-02" curvEnd="-0.0000000000000000e+00"/>
+            </geometry>
+            <geometry s="2.7337976354197622e+01" x="1.2329838899771316e+01" y="3.3795706085147725e+00" hdg="3.9525485867501148e-03" length="1.7658011205975583e+00">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="3.0216465008752468e+01" id="5" junction="1" rule="RHT">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="start" />
+            <successor elementType="road" elementId="1" contactPoint="end" />
+        </link>
+        <type s="0.0000000000000000e+00" country="DE" type="town"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="1.4107760519715248e+01" y="3.1657398578735929e-01" hdg="-3.1376401050080087e+00" length="1.3149956096124449e+00">
+                <line/>
+            </geometry>
+            <geometry s="1.3149956096124449e+00" x="1.2792775181941153e+01" y="3.1137641528232324e-01" hdg="-3.1376401050080096e+00" length="2.6205128479007631e+00">
+                <spiral curvStart="-0.0000000000000000e+00" curvEnd="-2.9799708954062393e-02"/>
+            </geometry>
+            <geometry s="3.9355084575132082e+00" x="1.0172547486544923e+01" y="3.3512253852022411e-01" hdg="3.1064999420839063e+00" length="2.6205128479003448e+00">
+                <arc curvature="-2.9799708954062393e-02"/>
+            </geometry>
+            <geometry s="6.5560213054135534e+00" x="7.5598970478971346e+00" y="5.2917480501762171e-01" hdg="3.0284094219060949e+00" length="2.6205128479007631e+00">
+                 <spiral curvStart="-2.9799708954062393e-02" curvEnd="-0.0000000000000000e+00"/>
+            </geometry>
+            <geometry s="9.1765341533143161e+00" x="4.9649123697959006e+00" y="8.9278390016040587e-01" hdg="2.9893641618208910e+00" length="1.1863396702134642e+01">
+                <line/>
+            </geometry>
+            <geometry s="2.1039930855448958e+01" x="-6.7612912836405759e+00" y="2.6917639418373920e+00" hdg="2.9893641618208910e+00" length="2.6205128478939894e+00">
+                <spiral curvStart="0.0000000000000000e+00" curvEnd="2.9799708954139557e-02"/>
+            </geometry>
+            <geometry s="2.3660443703342949e+01" x="-9.3562759618197084e+00" y="3.0553730369757979e+00" hdg="3.0284094219085613e+00" length="2.6205128478941520e+00">
+                <arc curvature="2.9799708954139557e-02"/>
+            </geometry>
+            <geometry s="2.6280956551237100e+01" x="-1.1968926400462799e+01" y="3.2494253034533043e+00" hdg="3.1064999420863906e+00" length="2.6205128478939894e+00">
+                 <spiral curvStart="2.9799708954139557e-02" curvEnd="0.0000000000000000e+00"/>
+            </geometry>
+            <geometry s="2.8901469399131088e+01" x="-1.4589154095768169e+01" y="3.2731714267142218e+00" hdg="-3.1376401050080087e+00" length="1.3149956096213817e+00">
+                <line/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" >
+                        <link>
+                        </link>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" direction="both">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0699999999999998e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <junction name="" id="1">
+        <connection id="0" incomingRoad="2" connectingRoad="4" contactPoint="end">
+        <laneLink from="-1" to="-1"/>
+    </connection>
+    <connection id="1" incomingRoad="3" connectingRoad="4" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+    </connection>
+    <connection id="2" incomingRoad="2" connectingRoad="5" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+    </connection>
+    <connection id="3" incomingRoad="1" connectingRoad="6" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+    </connection>
+    </junction>
+</OpenDRIVE>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+from lxml import etree
+from qc_opendrive.checks import utils
+
+
+def test_get_road_id_map() -> None:
+    root = etree.parse("tests/data/utils/Ex_Bidirectional_Junction.xodr")
+    road_id_map = utils.get_road_id_map(root)
+    assert len(road_id_map) == 6
+
+
+def test_get_junction_id_map() -> None:
+    root = etree.parse("tests/data/utils/Ex_Bidirectional_Junction.xodr")
+    junction_id_map = utils.get_junction_id_map(root)
+    assert len(junction_id_map) == 1


### PR DESCRIPTION
**Description**

Complete the check for rule `asam.net:xodr:1.7.0:road.lane.level_true_one_side` by adding inter-road and junction levels check.

**Main changes**

1. Add check for lane levels between connected roads and junctions.
2. Refactor the current implementation of this rule into four steps:
    ```python
    _check_level_in_lane_section
    _check_level_among_lane_sections
    _check_level_among_roads
    _check_level_among_junctions
    ```
3. Add more helper functions to `utils` and move all the commonly used data structures to `models`.

**How was the PR tested?**

1. Unit-test

**Notes**

Related issue: https://github.com/asam-ev/qc-opendrive/issues/2