### PR TITLE
Add checks for lanes across lane sections

### DIFF
--- a/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
@@ -1,0 +1,294 @@
+from dataclasses import dataclass
+import logging
+
+from typing import Union, List, Dict, Set
+from enum import Enum
+
+from lxml import etree
+
+from qc_baselib import Configuration, Result, IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.semantic import semantic_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.4.0"
+
+
+def _raise_predecessor_issues(
+    checker_data: models.CheckerData, rule_uid: str, lane_section: etree._ElementTree
+) -> None:
+    for lane in utils.get_left_and_right_lanes_from_lane_section(lane_section):
+        predecessor_lane_ids = utils.get_predecessor_lane_ids(lane)
+        for lane_id in predecessor_lane_ids:
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                description="Invalid predecessor lane id.",
+                level=IssueSeverity.ERROR,
+                rule_uid=rule_uid,
+            )
+
+            link = utils.get_lane_link_element(
+                lane, lane_id, models.LinkageTag.PREDECESSOR
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=checker_data.input_file_xml_root.getpath(link),
+                description="",
+            )
+
+
+def _raise_successor_issues(
+    checker_data: models.CheckerData, rule_uid: str, lane_section: etree._ElementTree
+) -> None:
+    for lane in utils.get_left_and_right_lanes_from_lane_section(lane_section):
+        successor_lane_ids = utils.get_successor_lane_ids(lane)
+        for lane_id in successor_lane_ids:
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                description="Invalid successor lane id.",
+                level=IssueSeverity.ERROR,
+                rule_uid=rule_uid,
+            )
+
+            link = utils.get_lane_link_element(
+                lane, lane_id, models.LinkageTag.SUCCESSOR
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=checker_data.input_file_xml_root.getpath(link),
+                description="",
+            )
+
+
+def _check_two_lane_sections(
+    checker_data: models.CheckerData,
+    rule_uid: str,
+    predecessor_lane_section: etree._ElementTree,
+    successor_lane_section: etree._ElementTree,
+) -> None:
+    for lane in utils.get_left_and_right_lanes_from_lane_section(
+        successor_lane_section
+    ):
+        current_lane_id = utils.get_lane_id(lane)
+        predecessor_lane_ids = utils.get_predecessor_lane_ids(lane)
+        for predecessor_lane_id in predecessor_lane_ids:
+            predecessor_lane = utils.get_lane_from_lane_section(
+                predecessor_lane_section, predecessor_lane_id
+            )
+
+            if predecessor_lane is None:
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description="Invalid predecessor lane id.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
+
+                link = utils.get_lane_link_element(
+                    lane, predecessor_lane_id, models.LinkageTag.PREDECESSOR
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(link),
+                    description="",
+                )
+
+                continue
+
+            successor_ids_of_predecessor_lane = utils.get_successor_lane_ids(
+                predecessor_lane
+            )
+
+            if current_lane_id not in successor_ids_of_predecessor_lane:
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description="Missing successor.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(predecessor_lane),
+                    description="",
+                )
+
+    for lane in utils.get_left_and_right_lanes_from_lane_section(
+        predecessor_lane_section
+    ):
+        current_lane_id = utils.get_lane_id(lane)
+        successor_lane_ids = utils.get_successor_lane_ids(lane)
+        for successor_lane_id in successor_lane_ids:
+            successor_lane = utils.get_lane_from_lane_section(
+                successor_lane_section, successor_lane_id
+            )
+
+            if successor_lane is None:
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description="Invalid successor lane id.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
+
+                link = utils.get_lane_link_element(
+                    lane, successor_lane_id, models.LinkageTag.SUCCESSOR
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(link),
+                    description="",
+                )
+
+                continue
+
+            predecessor_ids_of_successor_lane = utils.get_predecessor_lane_ids(
+                successor_lane
+            )
+
+            if current_lane_id not in predecessor_ids_of_successor_lane:
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description="Missing predecessor.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(successor_lane),
+                    description="",
+                )
+
+
+def _check_middle_lane_sections(
+    checker_data: models.CheckerData, road: etree._ElementTree, rule_uid: str
+) -> None:
+    lane_sections = utils.get_lane_sections(road)
+
+    if len(lane_sections) < 2:
+        return
+
+    for i in range(1, len(lane_sections)):
+        current_lane_section = lane_sections[i]
+        previous_lane_section = lane_sections[i - 1]
+        _check_two_lane_sections(
+            checker_data, rule_uid, previous_lane_section, current_lane_section
+        )
+
+
+def _check_first_lane_section(
+    checker_data: models.CheckerData,
+    road: etree._ElementTree,
+    road_id_map: Dict[int, etree._ElementTree],
+    rule_uid: str,
+) -> None:
+    first_lane_section = utils.get_first_lane_section(road)
+    if first_lane_section is None:
+        return
+
+    predecessor_road_id = utils.get_predecessor_road_id(road)
+    predecessor_road = road_id_map.get(predecessor_road_id)
+    if predecessor_road is None:
+        _raise_predecessor_issues(checker_data, rule_uid, first_lane_section)
+        return
+
+    last_lane_section_of_predecessor_road = utils.get_last_lane_section(
+        predecessor_road
+    )
+
+    if last_lane_section_of_predecessor_road is None:
+        _raise_predecessor_issues(checker_data, rule_uid, first_lane_section)
+        return
+
+    _check_two_lane_sections(
+        checker_data,
+        rule_uid,
+        last_lane_section_of_predecessor_road,
+        first_lane_section,
+    )
+
+
+def _check_last_lane_section(
+    checker_data: models.CheckerData,
+    road: etree._ElementTree,
+    road_id_map: Dict[int, etree._ElementTree],
+    rule_uid: str,
+) -> None:
+    last_lane_section = utils.get_last_lane_section(road)
+    if last_lane_section is None:
+        return
+
+    successor_road_id = utils.get_successor_road_id(road)
+    successor_road = road_id_map.get(successor_road_id)
+    if successor_road is None:
+        _raise_successor_issues(checker_data, rule_uid, last_lane_section)
+        return
+
+    first_lane_section_of_successor_road = utils.get_first_lane_section(successor_road)
+
+    if first_lane_section_of_successor_road is None:
+        _raise_successor_issues(checker_data, rule_uid, last_lane_section)
+        return
+
+    _check_two_lane_sections(
+        checker_data,
+        rule_uid,
+        last_lane_section,
+        first_lane_section_of_successor_road,
+    )
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule: Lanes that continues across the lane sections shall be connected in both directions.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/3
+    """
+    logging.info("Executing road.lane.link.lanes_across_lane_sections check.")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="road.lane.link.lanes_across_lane_sections",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    road_id_map = utils.get_road_id_map(checker_data.input_file_xml_root)
+
+    for road in utils.get_roads(checker_data.input_file_xml_root):
+        _check_middle_lane_sections(checker_data, road, rule_uid)
+        _check_first_lane_section(checker_data, road, road_id_map, rule_uid)
+        _check_last_lane_section(checker_data, road, road_id_map, rule_uid)

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -11,6 +11,7 @@ from qc_opendrive.checks.semantic import (
     semantic_constants,
     road_lane_level_true_one_side,
     road_lane_access_no_mix_of_deny_or_allow,
+    road_lane_link_lanes_across_lane_sections,
 )
 
 
@@ -31,6 +32,7 @@ def run_checks(config: Configuration, result: Result) -> None:
     rule_list = [
         road_lane_level_true_one_side.check_rule,
         road_lane_access_no_mix_of_deny_or_allow.check_rule,
+        road_lane_link_lanes_across_lane_sections.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -149,6 +149,22 @@ def get_road_linkage(
         return None
 
 
+def get_predecessor_road_id(road: etree._ElementTree) -> Union[None, int]:
+    linkage = get_road_linkage(road, models.LinkageTag.PREDECESSOR)
+    if linkage is None:
+        return None
+    else:
+        return linkage.id
+
+
+def get_successor_road_id(road: etree._ElementTree) -> Union[None, int]:
+    linkage = get_road_linkage(road, models.LinkageTag.SUCCESSOR)
+    if linkage is None:
+        return None
+    else:
+        return linkage.id
+
+
 def get_predecessor_lane_ids(lane: etree._ElementTree) -> List[int]:
     links = lane.findall("link")
 
@@ -175,6 +191,32 @@ def get_successor_lane_ids(lane: etree._ElementTree) -> List[int]:
                 successors.append(int(successor_id))
 
     return successors
+
+
+def get_lane_link_element(
+    lane: etree._ElementTree, link_id: int, linkage_tag: models.LinkageTag
+) -> Union[None, etree._ElementTree]:
+    links = lane.findall("link")
+    if linkage_tag == models.LinkageTag.PREDECESSOR:
+        for link in links:
+            linkages = link.findall("predecessor")
+            for linkage in linkages:
+                predecessor_id = linkage.get("id")
+                if predecessor_id is not None and link_id == int(predecessor_id):
+                    return linkage
+
+        return None
+    elif linkage_tag == models.LinkageTag.SUCCESSOR:
+        for link in links:
+            linkages = link.findall("successor")
+            for linkage in linkages:
+                successor_id = linkage.get("id")
+                if successor_id is not None and link_id == int(successor_id):
+                    return linkage
+
+        return None
+    else:
+        return None
 
 
 def get_lane_from_lane_section(
@@ -208,3 +250,11 @@ def get_connections_from_junction(
     junction: etree._ElementTree,
 ) -> List[etree._ElementTree]:
     return list(junction.iter("connection"))
+
+
+def get_lane_id(lane: etree._ElementTree) -> Union[None, int]:
+    lane_id = lane.get("id")
+    if lane_id is None:
+        return None
+    else:
+        return int(lane_id)

--- a/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_invalid.xodr
+++ b/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_invalid.xodr
@@ -1,0 +1,145 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="8" name="" version="1.00" date="Wed Aug  2 09:16:10 2023"
+    north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+    west="0.0000000000000000e+00">
+  </header>
+  <road name="" length="1.0000000000000000e+02" id="1" junction="-1" rule="RHT">
+    <link>
+    </link>
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="1.1970260013222610e+02" y="9.1508118250189384e+01"
+        hdg="5.1105731189804682e-01" length="1.0000000000000000e+02">
+        <line />
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00"
+        c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <successor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <successor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <successor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <successor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <successor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <successor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="50.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <predecessor id="4" /> <!-- issue: lane id not exist in previous lane section -->
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border"> <!-- issue: no lane link to previous lane section -->
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <predecessor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border"> <!-- issue: no lane link to previous lane section -->
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-4" /> <!-- issue: lane id not exist in previous lane section -->
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <objects>
+    </objects>
+    <signals>
+    </signals>
+    <surface>
+    </surface>
+  </road>
+</OpenDRIVE>

--- a/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_invalid_no_predecessor_road.xodr
+++ b/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_invalid_no_predecessor_road.xodr
@@ -1,0 +1,151 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="8" name="" version="1.00" date="Wed Aug  2 09:16:10 2023"
+    north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+    west="0.0000000000000000e+00">
+  </header>
+  <road name="" length="1.0000000000000000e+02" id="1" junction="-1" rule="RHT">
+    <link>
+    </link>
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="1.1970260013222610e+02" y="9.1508118250189384e+01"
+        hdg="5.1105731189804682e-01" length="1.0000000000000000e+02">
+        <line />
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00"
+        c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <successor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <successor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <successor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <predecessor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="50.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <predecessor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <predecessor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <predecessor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <predecessor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <objects>
+    </objects>
+    <signals>
+    </signals>
+    <surface>
+    </surface>
+  </road>
+</OpenDRIVE>

--- a/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_valid.xodr
+++ b/tests/data/road_lane_link_lanes_across_lane_sections/road_lane_link_lanes_across_lane_sections_valid.xodr
@@ -1,0 +1,151 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="8" name="" version="1.00" date="Wed Aug  2 09:16:10 2023"
+    north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+    west="0.0000000000000000e+00">
+  </header>
+  <road name="" length="1.0000000000000000e+02" id="1" junction="-1" rule="RHT">
+    <link>
+    </link>
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="1.1970260013222610e+02" y="9.1508118250189384e+01"
+        hdg="5.1105731189804682e-01" length="1.0000000000000000e+02">
+        <line />
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00"
+        c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <successor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <successor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <successor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <successor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <successor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <successor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="50.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <predecessor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <predecessor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <predecessor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <predecessor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <objects>
+    </objects>
+    <signals>
+    </signals>
+    <surface>
+    </surface>
+  </road>
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -282,3 +282,53 @@ def test_road_lane_true_level_one_side_junction(
     launch_main(monkeypatch)
     check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
     cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        # 3 issues for invalid predecessors + 3 issues for missing successors
+        (
+            "invalid_no_predecessor_road",
+            6,
+            [
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[1]/link/predecessor",
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[2]/link/predecessor",
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[3]/link/predecessor",
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[1]",
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[2]",
+                "/OpenDRIVE/road/lanes/laneSection[1]/right/lane[3]",
+            ],
+        ),
+        # 2 no link issues + 2 invalid link issues + 2 no link from the previous invalid link issues
+        (
+            "invalid",
+            6,
+            [
+                "/OpenDRIVE/road/lanes/laneSection[2]/left/lane[2]",
+                "/OpenDRIVE/road/lanes/laneSection[2]/right/lane[2]",
+                "/OpenDRIVE/road/lanes/laneSection[2]/left/lane[1]/link/predecessor",
+                "/OpenDRIVE/road/lanes/laneSection[2]/right/lane[3]/link/predecessor",
+                "/OpenDRIVE/road/lanes/laneSection[2]/left/lane[1]",
+                "/OpenDRIVE/road/lanes/laneSection[2]/right/lane[3]",
+            ],
+        ),
+    ],
+)
+def test_road_lane_link_lanes_across_lane_sections(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/road_lane_link_lanes_across_lane_sections/"
+    target_file_name = f"road_lane_link_lanes_across_lane_sections_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.4.0:road.lane.link.lanes_across_lane_sections"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()


### PR DESCRIPTION
**Description**

Complete the check for rule `asam.net:xodr:1.4.0:road.lane.link.lanes_across_lane_sections` by adding inter-road and junction levels check.

**Main changes**

1. Add check for the corresponding rule.
1. Add more helper functions to `utils`.

**How was the PR tested?**

1. Unit-test

**Notes**

Related issue: https://github.com/asam-ev/qc-opendrive/issues/3