### PR TITLE
Add rule to check junction connections using connecting road as incoming road

### DIFF
--- a/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
@@ -1,0 +1,88 @@
+import logging
+
+from typing import Dict, Set, List
+from lxml import etree
+
+from qc_baselib import IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.semantic import semantic_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.4.0"
+
+
+def _check_junctions_connection_connect_road_no_incoming_road(
+    checker_data: models.CheckerData, rule_uid: str
+) -> None:
+    junctions = utils.get_junctions(checker_data.input_file_xml_root)
+
+    incoming_road_ids = set()
+    connecting_road_ids = set()
+
+    incoming_road_connection_map: Dict[int, List[etree._Element]] = {}
+
+    for junction in junctions:
+        connections = utils.get_connections_from_junction(junction)
+
+        for connection in connections:
+            incoming_road_id = utils.get_connection_incoming_roa_id(connection)
+            connecting_road_id = utils.get_connection_connecting_roa_id(connection)
+
+            incoming_road_ids.add(incoming_road_id)
+            connecting_road_ids.add(connecting_road_id)
+
+            if incoming_road_id not in incoming_road_connection_map:
+                incoming_road_connection_map[incoming_road_id] = []
+
+            incoming_road_connection_map[incoming_road_id].append(connection)
+
+    incoming_connecting_intersection = incoming_road_ids.intersection(
+        connecting_road_ids
+    )
+
+    for intersection_road_id in list(incoming_connecting_intersection):
+        issue_id = checker_data.result.register_issue(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=semantic_constants.CHECKER_ID,
+            description=f"Connecting roads shall not be incoming roads.",
+            level=IssueSeverity.ERROR,
+            rule_uid=rule_uid,
+        )
+
+        for element in incoming_road_connection_map[intersection_road_id]:
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=checker_data.input_file_xml_root.getpath(element),
+                description="Connection with connecting road found as incoming road.",
+            )
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements a rule to check if a junction connecting roads are also incoming
+    roads.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/6
+    """
+    logging.info("Executing junctions.connection.connect_road_no_incoming_road check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="junctions.connection.connect_road_no_incoming_road",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    _check_junctions_connection_connect_road_no_incoming_road(checker_data, rule_uid)

--- a/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
@@ -16,48 +16,31 @@ def _check_junctions_connection_connect_road_no_incoming_road(
     checker_data: models.CheckerData, rule_uid: str
 ) -> None:
     junctions = utils.get_junctions(checker_data.input_file_xml_root)
-
-    incoming_road_ids = set()
-    connecting_road_ids = set()
-
-    incoming_road_connection_map: Dict[int, List[etree._Element]] = {}
+    road_id_map = utils.get_road_id_map(checker_data.input_file_xml_root)
 
     for junction in junctions:
         connections = utils.get_connections_from_junction(junction)
 
         for connection in connections:
-            incoming_road_id = utils.get_connection_incoming_roa_id(connection)
-            connecting_road_id = utils.get_connection_connecting_roa_id(connection)
+            incoming_road_id = utils.get_incoming_road_id_from_connection(connection)
+            incoming_road = road_id_map[incoming_road_id]
 
-            incoming_road_ids.add(incoming_road_id)
-            connecting_road_ids.add(connecting_road_id)
+            if utils.road_belongs_to_junction(incoming_road):
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description=f"Connecting roads shall not be incoming roads.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
 
-            if incoming_road_id not in incoming_road_connection_map:
-                incoming_road_connection_map[incoming_road_id] = []
-
-            incoming_road_connection_map[incoming_road_id].append(connection)
-
-    incoming_connecting_intersection = incoming_road_ids.intersection(
-        connecting_road_ids
-    )
-
-    for intersection_road_id in list(incoming_connecting_intersection):
-        issue_id = checker_data.result.register_issue(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=semantic_constants.CHECKER_ID,
-            description=f"Connecting roads shall not be incoming roads.",
-            level=IssueSeverity.ERROR,
-            rule_uid=rule_uid,
-        )
-
-        for element in incoming_road_connection_map[intersection_road_id]:
-            checker_data.result.add_xml_location(
-                checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=semantic_constants.CHECKER_ID,
-                issue_id=issue_id,
-                xpath=checker_data.input_file_xml_root.getpath(element),
-                description="Connection with connecting road found as incoming road.",
-            )
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(connection),
+                    description="Connection with connecting road found as incoming road.",
+                )
 
 
 def check_rule(checker_data: models.CheckerData) -> None:

--- a/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Dict, Set, List
+from typing import Dict, List
 from lxml import etree
 
 from qc_baselib import IssueSeverity

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -13,6 +13,7 @@ from qc_opendrive.checks.semantic import (
     road_lane_access_no_mix_of_deny_or_allow,
     road_lane_link_lanes_across_lane_sections,
     road_linkage_is_junction_needed,
+    junctions_connection_connect_road_no_incoming_road,
 )
 
 
@@ -35,6 +36,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_lane_access_no_mix_of_deny_or_allow.check_rule,
         road_lane_link_lanes_across_lane_sections.check_rule,
         road_linkage_is_junction_needed.check_rule,
+        junctions_connection_connect_road_no_incoming_road.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -300,3 +300,19 @@ def road_belongs_to_junction(road: etree._Element) -> bool:
         return False
     else:
         return True
+
+
+def get_connection_incoming_roa_id(connection: etree._Element) -> Union[None, int]:
+    incoming_road_id = connection.get("incomingRoad")
+    if incoming_road_id is None:
+        return None
+    else:
+        return int(incoming_road_id)
+
+
+def get_connection_connecting_roa_id(connection: etree._Element) -> Union[None, int]:
+    connecting_roa_id = connection.get("connectingRoad")
+    if connecting_roa_id is None:
+        return None
+    else:
+        return int(connecting_roa_id)

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -302,7 +302,9 @@ def road_belongs_to_junction(road: etree._Element) -> bool:
         return True
 
 
-def get_connection_incoming_roa_id(connection: etree._Element) -> Union[None, int]:
+def get_incoming_road_id_from_connection(
+    connection: etree._Element,
+) -> Union[None, int]:
     incoming_road_id = connection.get("incomingRoad")
     if incoming_road_id is None:
         return None
@@ -310,7 +312,9 @@ def get_connection_incoming_roa_id(connection: etree._Element) -> Union[None, in
         return int(incoming_road_id)
 
 
-def get_connection_connecting_roa_id(connection: etree._Element) -> Union[None, int]:
+def get_connecting_road_id_from_connection(
+    connection: etree._Element,
+) -> Union[None, int]:
     connecting_roa_id = connection.get("connectingRoad")
     if connecting_roa_id is None:
         return None

--- a/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_invalid.xodr
+++ b/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_invalid.xodr
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="5" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="B" length="1.11799576481966e+01" id="2" junction="100">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+			<successor elementType="road" elementId="4" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.92072522639830e-04" y="-4.02591407299369e-04" hdg="2.03436958379066e+00" length="1.11799576481966e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="C" length="1.11806552555667e+01" id="3" junction="100">
+		<link>
+             <predecessor elementType="road" elementId="1" contactPoint="end" />
+			 <successor elementType="road" elementId="5" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="4.56982851027021e-06" y="1.57623291014986e-05" hdg="1.10713287685699e+00" length="1.11806552555667e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="D" length="1.06420550914178e+01" id="4" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.99957762145996e+00" y="9.99962724304199e+00" hdg="1.87068468944466e+00" length="1.06420550914178e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="E" length="9.75242055555372e+00" id="5" junction="-1">
+		<link>
+            <predecessor elementType="road" elementId="5" contactPoint="end" />
+			<successor elementType="road" elementId="8" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="5.80" y="9.65" hdg="0.45" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="F" length="9.75242055555372e+00" id="6" junction="-1">
+		<link>
+            <predecessor elementType="road" elementId="5" contactPoint="end" />
+			<successor elementType="road" elementId="9" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="4.3" y="8.5" hdg="1.5" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="G" length="9.75242055555372e+00" id="7" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="101"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="14.48" y="13.75" hdg="0.45" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="H" length="9.75242055555372e+00" id="8" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="101"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="4.9" y="18.10" hdg="1.5" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="1" incomingRoad="1" connectingRoad="3" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+    <junction name="secondary" id="101" type="default">
+        <connection id="2" incomingRoad="3" connectingRoad="5" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection id="3" incomingRoad="3" connectingRoad="6" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_valid.xodr
+++ b/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_valid.xodr
@@ -169,7 +169,7 @@
 		</lanes>
 	</road>
 
-    <road name="F" length="9.75242055555372e+00" id="6" junction="-1">
+    <road name="F" length="9.75242055555372e+00" id="6" junction="101">
 		<link>
             <predecessor elementType="road" elementId="5" contactPoint="end" />
 			<successor elementType="road" elementId="8" contactPoint="start"/>
@@ -202,7 +202,7 @@
 		</lanes>
 	</road>
 
-    <road name="G" length="9.75242055555372e+00" id="7" junction="-1">
+    <road name="G" length="9.75242055555372e+00" id="7" junction="101">
 		<link>
             <predecessor elementType="road" elementId="5" contactPoint="end" />
 			<successor elementType="road" elementId="9" contactPoint="start"/>
@@ -267,7 +267,7 @@
 		</lanes>
 	</road>
 
-    <road name="I" length="9.75242055555372e+00" id="8" junction="-1">
+    <road name="I" length="9.75242055555372e+00" id="9" junction="-1">
 		<link>
             <predecessor elementType="junction" elementId="101"/>
         </link>

--- a/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_valid.xodr
+++ b/tests/data/junctions_connection_connect_road_no_incoming_road/junctions_connection_connect_road_no_incoming_road_valid.xodr
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="5" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="B" length="1.11799576481966e+01" id="2" junction="100">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+			<successor elementType="road" elementId="4" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.92072522639830e-04" y="-4.02591407299369e-04" hdg="2.03436958379066e+00" length="1.11799576481966e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="C" length="1.11806552555667e+01" id="3" junction="100">
+		<link>
+             <predecessor elementType="road" elementId="1" contactPoint="end" />
+			 <successor elementType="road" elementId="5" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="4.56982851027021e-06" y="1.57623291014986e-05" hdg="1.10713287685699e+00" length="1.11806552555667e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="D" length="1.06420550914178e+01" id="4" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.99957762145996e+00" y="9.99962724304199e+00" hdg="1.87068468944466e+00" length="1.06420550914178e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="E" length="9.75242055555372e+00" id="5" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="5.00030401992798e+00" y="1.00002186279297e+01" hdg="1.26653372811126e+00" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="F" length="9.75242055555372e+00" id="6" junction="-1">
+		<link>
+            <predecessor elementType="road" elementId="5" contactPoint="end" />
+			<successor elementType="road" elementId="8" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="8.3" y="19.00" hdg="0.8" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="G" length="9.75242055555372e+00" id="7" junction="-1">
+		<link>
+            <predecessor elementType="road" elementId="5" contactPoint="end" />
+			<successor elementType="road" elementId="9" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="7.7" y="18.55" hdg="1.5" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="H" length="9.75242055555372e+00" id="8" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="101"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="15.00" y="26" hdg="0.8" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <road name="I" length="9.75242055555372e+00" id="8" junction="-1">
+		<link>
+            <predecessor elementType="junction" elementId="101"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="8.4" y="28.0" hdg="1.5" length="9.75242055555372e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="1" incomingRoad="1" connectingRoad="3" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+    <junction name="secondary" id="101" type="default">
+        <connection id="2" incomingRoad="5" connectingRoad="6" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection id="3" incomingRoad="5" connectingRoad="7" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -364,3 +364,38 @@ def test_road_linkage_is_junction_needed(
     launch_main(monkeypatch)
     check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
     cleanup_files()
+
+
+#
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        (
+            "invalid",
+            1,
+            [
+                "/OpenDRIVE/junction[2]/connection[1]",
+                "/OpenDRIVE/junction[2]/connection[2]",
+            ],
+        ),
+    ],
+)
+def test_junctions_connection_road_no_incoming_road(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/junctions_connection_connect_road_no_incoming_road/"
+    target_file_name = (
+        f"junctions_connection_connect_road_no_incoming_road_{target_file}.xodr"
+    )
+    rule_uid = "asam.net:xodr:1.4.0:junctions.connection.connect_road_no_incoming_road"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -373,7 +373,7 @@ def test_road_linkage_is_junction_needed(
         ("valid", 0, []),
         (
             "invalid",
-            1,
+            2,
             [
                 "/OpenDRIVE/junction[2]/connection[1]",
                 "/OpenDRIVE/junction[2]/connection[2]",


### PR DESCRIPTION
**Description**

This PR adds to the checker a rule to verify if connecting roads are being set as incoming roads in junctions.

**Main changes**

1. Add junctions.connection.connect_road_no_incoming_road rule implementation
2. Add test with example files
3. Add some connection methods to utils module

**How was the PR tested?**

1. Unit-test are passing with the addition of the new test cases.
2. Tested with a few OpenDrive examples and the rule is working as expected.

**Notes**
- Related to https://github.com/asam-ev/qc-opendrive/issues/6