### PR TITLE
Add rule to check if connecting road is used more than once on junction connection

### DIFF
--- a/qc_opendrive/checks/semantic/__init__.py
+++ b/qc_opendrive/checks/semantic/__init__.py
@@ -8,3 +8,7 @@ from . import road_linkage_is_junction_needed as road_linkage_is_junction_needed
 from . import (
     road_lane_link_lanes_across_lane_sections as road_lane_link_lanes_across_lane_sections,
 )
+
+from . import (
+    junctions_connection_one_connection_element as junctions_connection_one_connection_element,
+)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -60,6 +60,17 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
     More info at
         - https://github.com/asam-ev/qc-opendrive/issues/6
+
+    Rule ID: junctions.connection.one_connection_element
+
+    Description: Each connecting road shall be represented by exactly one
+    element. A connecting road may contain as many lanes as required.
+
+    Severity: ERROR
+
+    Version range: From 1.7.0 to 1.7.0
+
+    Rule Version: 0.1
     """
     logging.info("Executing junctions.connection.one_connection_element check")
 

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -1,0 +1,81 @@
+import logging
+
+from typing import Dict, List
+from lxml import etree
+
+from qc_baselib import IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.semantic import semantic_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.7.0"
+
+
+def _check_junctions_connection_one_connection_element(
+    checker_data: models.CheckerData, rule_uid: str
+) -> None:
+    junctions = utils.get_junctions(checker_data.input_file_xml_root)
+
+    connecting_road_id_connections_map: Dict[int, List[etree._Element]] = {}
+
+    for junction in junctions:
+        connections = utils.get_connections_from_junction(junction)
+
+        for connection in connections:
+            connecting_road_id = utils.get_connecting_road_id_from_connection(
+                connection
+            )
+
+            if connecting_road_id not in connecting_road_id_connections_map:
+                connecting_road_id_connections_map[connecting_road_id] = []
+
+            connecting_road_id_connections_map[connecting_road_id].append(connection)
+
+    for connections in connecting_road_id_connections_map.values():
+        # connecting road id cannot be appear in more than 1 <connection> element
+        if len(connections) > 1:
+            # we raise 1 issue with all repeated locations for each repeated id
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                description=f"Connecting roads shall be represented by only one <connection> element.",
+                level=IssueSeverity.ERROR,
+                rule_uid=rule_uid,
+            )
+            for connection in connections:
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=checker_data.input_file_xml_root.getpath(connection),
+                    description="Connection with reused connecting road id.",
+                )
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements a rule to check if a junction connecting roads are also incoming
+    roads.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/6
+    """
+    logging.info("Executing junctions.connection.one_connection_element check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="junctions.connection.one_connection_element",
+    )
+
+    if checker_data.schema_version == RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    _check_junctions_connection_one_connection_element(checker_data, rule_uid)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -32,14 +32,14 @@ def _check_junctions_connection_one_connection_element(
 
             connecting_road_id_connections_map[connecting_road_id].append(connection)
 
-    for connections in connecting_road_id_connections_map.values():
+    for connecting_road_id, connections in connecting_road_id_connections_map.items():
         # connecting road id cannot be appear in more than 1 <connection> element
         if len(connections) > 1:
             # we raise 1 issue with all repeated locations for each repeated id
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
                 checker_id=semantic_constants.CHECKER_ID,
-                description=f"Connecting roads shall be represented by only one <connection> element.",
+                description=f"Connecting road {connecting_road_id} shall be represented by only one <connection> element.",
                 level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
@@ -72,7 +72,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
         rule_full_name="junctions.connection.one_connection_element",
     )
 
-    if checker_data.schema_version == RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+    if checker_data.schema_version != RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
         logging.info(
             f"Schema version {checker_data.schema_version} not supported. Skipping rule."
         )

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -14,6 +14,7 @@ from qc_opendrive.checks.semantic import (
     road_lane_link_lanes_across_lane_sections,
     road_linkage_is_junction_needed,
     junctions_connection_connect_road_no_incoming_road,
+    junctions_connection_one_connection_element,
 )
 
 
@@ -37,6 +38,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_lane_link_lanes_across_lane_sections.check_rule,
         road_linkage_is_junction_needed.check_rule,
         junctions_connection_connect_road_no_incoming_road.check_rule,
+        junctions_connection_one_connection_element.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_invalid.xodr
+++ b/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_invalid.xodr
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="7" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100">
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_valid.xodr
+++ b/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_valid.xodr
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="7" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+			<successor elementType="road" elementId="3" contactPoint="start"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -374,7 +374,6 @@ def test_road_linkage_is_junction_needed(
     cleanup_files()
 
 
-#
 @pytest.mark.parametrize(
     "target_file,issue_count,issue_xpath",
     [
@@ -400,6 +399,38 @@ def test_junctions_connection_road_no_incoming_road(
         f"junctions_connection_connect_road_no_incoming_road_{target_file}.xodr"
     )
     rule_uid = "asam.net:xodr:1.4.0:junctions.connection.connect_road_no_incoming_road"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        (
+            "invalid",
+            1,
+            [
+                "/OpenDRIVE/junction/connection[1]",
+                "/OpenDRIVE/junction/connection[2]",
+            ],
+        ),
+    ],
+)
+def test_junctions_connection_one_connection_element(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/junctions_connection_one_connection_element/"
+    target_file_name = f"junctions_connection_one_connection_element_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.7.0:junctions.connection.one_connection_element"
     issue_severity = IssueSeverity.ERROR
 
     target_file_path = os.path.join(base_path, target_file_name)


### PR DESCRIPTION
**Description**

This PR adds a rule to check if a connecting road is added to more than one junction connection. This rule is only applied to schema version `1.7.0`.

**Main changes**

1. Add rule implementation
2. Add test with examples

**How was the PR tested?**

1. Unit-test with some sample data. 

**Notes**
- Related to https://github.com/asam-ev/qc-opendrive/issues/9