### PR TITLE
Add rule to check one link to incoming rule

### DIFF
--- a/qc_opendrive/checks/semantic/__init__.py
+++ b/qc_opendrive/checks/semantic/__init__.py
@@ -12,3 +12,7 @@ from . import (
 from . import (
     junctions_connection_one_connection_element as junctions_connection_one_connection_element,
 )
+
+from . import (
+    junctions_connection_one_link_to_incoming as junctions_connection_one_link_to_incoming,
+)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -55,11 +55,11 @@ def _check_junctions_connection_one_connection_element(
 
 def check_rule(checker_data: models.CheckerData) -> None:
     """
-    Implements a rule to check if a junction connecting roads are also incoming
-    roads.
+    Implements a rule to check if a junction connecting roads are also used
+    more than once.
 
     More info at
-        - https://github.com/asam-ev/qc-opendrive/issues/6
+        - https://github.com/asam-ev/qc-opendrive/issues/9
 
     Rule ID: junctions.connection.one_connection_element
 

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -71,24 +71,25 @@ def _check_connection_lane_link_same_direction(
 
     # If the connection contact point is start we get the incoming road from
     # predecessor, otherwise we can get from the successor.
+    connecting_road_linkage = None
     if contact_point == models.ContactPoint.START:
-        incoming_linkage = utils.get_road_linkage(
+        connecting_road_linkage = utils.get_road_linkage(
             connecting_road, models.LinkageTag.PREDECESSOR
         )
     elif contact_point == models.ContactPoint.END:
-        incoming_linkage = utils.get_road_linkage(
+        connecting_road_linkage = utils.get_road_linkage(
             connecting_road, models.LinkageTag.SUCCESSOR
         )
     else:
         return
 
-    if incoming_linkage is None:
+    if connecting_road_linkage is None:
         return
 
     incoming_lane_section = None
-    if incoming_linkage.contact_point == models.ContactPoint.START:
+    if connecting_road_linkage.contact_point == models.ContactPoint.START:
         incoming_lane_section = utils.get_first_lane_section(incoming_road)
-    elif incoming_linkage.contact_point == models.ContactPoint.END:
+    elif connecting_road_linkage.contact_point == models.ContactPoint.END:
         incoming_lane_section = utils.get_last_lane_section(incoming_road)
     else:
         return

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -1,0 +1,172 @@
+import logging
+
+from typing import Dict, List
+from lxml import etree
+
+from qc_baselib import IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.semantic import semantic_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.8.0"
+
+
+def _check_connection_lane_link_same_direction(
+    checker_data: models.CheckerData,
+    road_id_map: Dict[int, etree._ElementTree],
+    connection: etree._Element,
+    rule_uid: str,
+) -> None:
+    contact_point = utils.get_contact_point_from_connection(connection)
+
+    # if not explicitly added we assume start as default
+    if contact_point is None:
+        contact_point = models.ContactPoint.START
+
+    incoming_road_id = utils.get_incoming_road_id_from_connection(connection)
+    connecting_road_id = utils.get_connecting_road_id_from_connection(connection)
+
+    incoming_road_last_lane_section = utils.get_last_lane_section(
+        road_id_map[incoming_road_id]
+    )
+    connecting_road_id_first_lane_section = utils.get_first_lane_section(
+        road_id_map[connecting_road_id]
+    )
+
+    lane_links = utils.get_lane_links_from_connection(connection)
+
+    for lane_link in lane_links:
+        from_lane_id = utils.get_from_attribute_from_lane_link(lane_link)
+        to_lane_id = utils.get_to_attribute_from_lane_link(lane_link)
+
+        from_lane = None
+        to_lane = None
+        if contact_point == models.ContactPoint.START:
+            from_lane = utils.get_lane_from_lane_section(
+                incoming_road_last_lane_section, from_lane_id
+            )
+            to_lane = utils.get_lane_from_lane_section(
+                connecting_road_id_first_lane_section, to_lane_id
+            )
+
+        else:
+            from_lane = utils.get_lane_from_lane_section(
+                connecting_road_id_first_lane_section, from_lane_id
+            )
+            to_lane = utils.get_lane_from_lane_section(
+                incoming_road_last_lane_section, to_lane_id
+            )
+
+        if from_lane is None or to_lane is None:
+            # raise one issue if a lane link is found in the opposite direction
+            # of the connecting road
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                description=f"A connecting road shall only have the <laneLink> element for that direction.",
+                level=IssueSeverity.ERROR,
+                rule_uid=rule_uid,
+            )
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=semantic_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=checker_data.input_file_xml_root.getpath(lane_link),
+                description=f"Lane link in opposite direction.",
+            )
+
+
+def _check_junctions_connection_one_link_to_incoming(
+    checker_data: models.CheckerData, rule_uid: str
+) -> None:
+    junctions = utils.get_junctions(checker_data.input_file_xml_root)
+    road_id_map = utils.get_road_id_map(checker_data.input_file_xml_root)
+
+    connection_road_link_map: Dict[int, Dict[int, List[etree._Element]]] = {}
+
+    for junction in junctions:
+        connections = utils.get_connections_from_junction(junction)
+
+        for connection in connections:
+            incoming_road_id = utils.get_incoming_road_id_from_connection(connection)
+            connecting_road_id = utils.get_connecting_road_id_from_connection(
+                connection
+            )
+
+            if incoming_road_id not in connection_road_link_map:
+                connection_road_link_map[incoming_road_id] = {}
+            if connecting_road_id not in connection_road_link_map[incoming_road_id]:
+                connection_road_link_map[incoming_road_id][connecting_road_id] = []
+
+            connection_road_link_map[incoming_road_id][connecting_road_id].append(
+                connection
+            )
+
+            _check_connection_lane_link_same_direction(
+                checker_data, road_id_map, connection, rule_uid
+            )
+
+    for incoming_road_id, connecting_road_map in connection_road_link_map.items():
+        for connecting_road_id, connections in connecting_road_map.items():
+            if len(connections) > 1:
+                # raise one issue if the pair (incoming_road_id, connecting_road_id)
+                # appears in more than one connection.
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=semantic_constants.CHECKER_ID,
+                    description=f"Connecting road {connecting_road_id} shall be represented by at most one <connection> element per incoming road id.",
+                    level=IssueSeverity.ERROR,
+                    rule_uid=rule_uid,
+                )
+                for connection in connections:
+                    checker_data.result.add_xml_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=semantic_constants.CHECKER_ID,
+                        issue_id=issue_id,
+                        xpath=checker_data.input_file_xml_root.getpath(connection),
+                        description=f"Connection with reused (incoming_road_id, connecting_road_id) = ({incoming_road_id}, {connecting_road_id}) pair.",
+                    )
+
+    return
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements a rule to check if a junction connecting roads are linked to
+    the same incoming road more than once, and if their lane links follow the
+    proper direction.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/10
+
+    Rule ID: junctions.connection.one_link_to_incoming
+
+    Description: Each connecting road shall be associated with at most one
+    <connection> element per incoming road. A connecting road shall only have
+    the <laneLink> element for that direction.
+
+    Severity: ERROR
+
+    Version range: From 1.8.0
+
+    Rule Version: 0.1
+    """
+    logging.info("Executing junctions.connection.one_link_to_incoming check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="junctions.connection.one_link_to_incoming",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    _check_junctions_connection_one_link_to_incoming(checker_data, rule_uid)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -158,7 +158,7 @@ def _check_junctions_connection_one_link_to_incoming(
 
 def check_rule(checker_data: models.CheckerData) -> None:
     """
-    Rule ID: asam.net:xodr:1.7.0:junctions.connection.one_link_to_incoming
+    Rule ID: asam.net:xodr:1.8.0:junctions.connection.one_link_to_incoming
 
     Description: Each connecting road shall be associated with at most one
     <connection> element per incoming road. A connecting road shall only have

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -15,6 +15,7 @@ from qc_opendrive.checks.semantic import (
     road_linkage_is_junction_needed,
     junctions_connection_connect_road_no_incoming_road,
     junctions_connection_one_connection_element,
+    junctions_connection_one_link_to_incoming,
 )
 
 
@@ -39,6 +40,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_linkage_is_junction_needed.check_rule,
         junctions_connection_connect_road_no_incoming_road.check_rule,
         junctions_connection_one_connection_element.check_rule,
+        junctions_connection_one_link_to_incoming.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -320,3 +320,21 @@ def get_connecting_road_id_from_connection(
         return None
     else:
         return int(connecting_roa_id)
+
+
+def get_contact_point_from_connection(
+    connection: etree._Element,
+) -> Union[None, models.ContactPoint]:
+    contact_point_str = connection.get("contactPoint")
+    if contact_point_str is None:
+        return None
+    else:
+        return models.ContactPoint(contact_point_str)
+
+
+def get_from_attribute_from_lane_link(lane_link: etree._Element) -> str:
+    return int(lane_link.get("from"))
+
+
+def get_to_attribute_from_lane_link(lane_link: etree._Element):
+    return int(lane_link.get("to"))

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -333,8 +333,16 @@ def get_contact_point_from_connection(
 
 
 def get_from_attribute_from_lane_link(lane_link: etree._Element) -> str:
-    return int(lane_link.get("from"))
+    from_attribute = lane_link.get("from")
+    if from_attribute is None:
+        return None
+    else:
+        return int(from_attribute)
 
 
 def get_to_attribute_from_lane_link(lane_link: etree._Element):
-    return int(lane_link.get("to"))
+    to_attribute = lane_link.get("to")
+    if to_attribute is None:
+        return None
+    else:
+        return int(to_attribute)

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100">
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="-1" to="2" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
@@ -44,6 +44,10 @@
 		</lanes>
 	</road>
     <road name="B" length="10.0" id="2" junction="100">
+		<link>
+			<predecessor elementType="road" elementId="1" contactPoint="end"/>
+			<successor elementType="road" elementId="3" contactPoint="start"/>
+		</link>
 		<planView>
 			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
 				<line />

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid.xodr
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100">
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -438,3 +438,36 @@ def test_junctions_connection_one_connection_element(
     launch_main(monkeypatch)
     check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
     cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        (
+            "invalid",
+            2,
+            [
+                "/OpenDRIVE/junction/connection[1]",
+                "/OpenDRIVE/junction/connection[2]",
+                "/OpenDRIVE/junction/connection[2]/laneLink",
+            ],
+        ),
+    ],
+)
+def test_junctions_connection_one_link_to_incoming(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/junctions_connection_one_link_to_incoming/"
+    target_file_name = f"junctions_connection_one_link_to_incoming_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.8.0:junctions.connection.one_link_to_incoming"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()


### PR DESCRIPTION
**Description**

This PR adds a check for the connection rule for connecting roads in junctions. The rule defines that at most one `<connection>` element can be linked to a connecting road per incoming road. It also states the `<laneLink>` should follow the direction of the connecting road per `<connection>`

**Main changes**

1. Add one link to incoming rule check 
2. Add utils for connection lane link
3. Add examples for tests
4. Add tests for new function

**How was the PR tested?**

1. Unit-test with some sample data. 
2. Tested with ASAM OpenDrive 1.8 junction examples.

**Notes**
- Related to https://github.com/asam-ev/qc-opendrive/issues/10