### PR TITLE
Fix junction lane link direction rule implementation

### DIFF
--- a/qc_opendrive/checks/models.py
+++ b/qc_opendrive/checks/models.py
@@ -65,3 +65,8 @@ class ContactingLaneSections:
 class WidthPoly3:
     poly3: Poly3
     s_offset: float
+
+
+class TrafficHandRule(str, Enum):
+    LHT = "LHT"
+    RHT = "RHT"

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -71,18 +71,18 @@ def _check_connection_lane_link_same_direction(
         if traffic_hand == models.TrafficHandRule.RHT:
             if contact_point == models.ContactPoint.START and predecessor is not None:
                 if predecessor.contact_point == models.ContactPoint.END:
-                    if from_lane_id != -1 or to_lane_id != -1:
+                    if from_lane_id > 0 or to_lane_id > 0:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
                 elif predecessor.contact_point == models.ContactPoint.START:
-                    if from_lane_id != 1 or to_lane_id != -1:
+                    if from_lane_id < 0 or to_lane_id > 0:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 
             if contact_point == models.ContactPoint.END and successor is not None:
                 if successor.contact_point == models.ContactPoint.END:
-                    if from_lane_id != -1 or to_lane_id != 1:
+                    if from_lane_id > 0 or to_lane_id < 0:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
                 elif successor.contact_point == models.ContactPoint.START:
-                    if from_lane_id != 1 or to_lane_id != 1:
+                    if from_lane_id < 0 or to_lane_id < 0:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 
         elif traffic_hand == models.TrafficHandRule.LHT:

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -86,7 +86,21 @@ def _check_connection_lane_link_same_direction(
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 
         elif traffic_hand == models.TrafficHandRule.LHT:
-            continue
+            if contact_point == models.ContactPoint.START and predecessor is not None:
+                if predecessor.contact_point == models.ContactPoint.END:
+                    if from_lane_id < 0 or to_lane_id < 0:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+                elif predecessor.contact_point == models.ContactPoint.START:
+                    if from_lane_id > 0 or to_lane_id < 0:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+
+            if contact_point == models.ContactPoint.END and successor is not None:
+                if successor.contact_point == models.ContactPoint.END:
+                    if from_lane_id < 0 or to_lane_id > 0:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+                elif successor.contact_point == models.ContactPoint.START:
+                    if from_lane_id > 0 or to_lane_id > 0:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 
 
 def _check_junctions_connection_one_link_to_incoming(

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -39,30 +39,54 @@ def _check_connection_lane_link_same_direction(
     connection: etree._Element,
     rule_uid: str,
 ) -> None:
-    contact_lane_sections = utils.get_incoming_and_connection_contacting_lane_sections(
-        connection, road_id_map
-    )
+    contact_point = utils.get_contact_point_from_connection(connection)
 
-    if contact_lane_sections is None:
+    if contact_point is None:
         return
 
+    incoming_road_id = utils.get_incoming_road_id_from_connection(connection)
+    connecting_road_id = utils.get_connecting_road_id_from_connection(connection)
+
+    if connecting_road_id is None or incoming_road_id is None:
+        return
+
+    connecting_road = road_id_map.get(connecting_road_id)
+
+    if connecting_road is None:
+        return
+
+    predecessor = utils.get_road_linkage(connecting_road, models.LinkageTag.PREDECESSOR)
+    successor = utils.get_road_linkage(connecting_road, models.LinkageTag.SUCCESSOR)
+
     lane_links = utils.get_lane_links_from_connection(connection)
+    traffic_hand = utils.get_road_hand_rule(connecting_road)
 
     for lane_link in lane_links:
         from_lane_id = utils.get_from_attribute_from_lane_link(lane_link)
         to_lane_id = utils.get_to_attribute_from_lane_link(lane_link)
 
-        from_lane = utils.get_lane_from_lane_section(
-            contact_lane_sections.incoming, from_lane_id
-        )
-        to_lane = utils.get_lane_from_lane_section(
-            contact_lane_sections.connection, to_lane_id
-        )
+        if from_lane_id is None or to_lane_id is None:
+            continue
 
-        if from_lane is None:
-            _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
-        if to_lane is None:
-            _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+        if traffic_hand == models.TrafficHandRule.RHT:
+            if contact_point == models.ContactPoint.START and predecessor is not None:
+                if predecessor.contact_point == models.ContactPoint.END:
+                    if from_lane_id != -1 or to_lane_id != -1:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+                if predecessor.contact_point == models.ContactPoint.START:
+                    if from_lane_id != 1 or to_lane_id != -1:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+
+            if contact_point == models.ContactPoint.END and successor is not None:
+                if successor.contact_point == models.ContactPoint.END:
+                    if from_lane_id != -1 or to_lane_id != 1:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+                if successor.contact_point == models.ContactPoint.START:
+                    if from_lane_id != 1 or to_lane_id != 1:
+                        _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
+
+        elif traffic_hand == models.TrafficHandRule.LHT:
+            continue
 
 
 def _check_junctions_connection_one_link_to_incoming(

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -73,7 +73,7 @@ def _check_connection_lane_link_same_direction(
                 if predecessor.contact_point == models.ContactPoint.END:
                     if from_lane_id != -1 or to_lane_id != -1:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
-                if predecessor.contact_point == models.ContactPoint.START:
+                elif predecessor.contact_point == models.ContactPoint.START:
                     if from_lane_id != 1 or to_lane_id != -1:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 
@@ -81,7 +81,7 @@ def _check_connection_lane_link_same_direction(
                 if successor.contact_point == models.ContactPoint.END:
                     if from_lane_id != -1 or to_lane_id != 1:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
-                if successor.contact_point == models.ContactPoint.START:
+                elif successor.contact_point == models.ContactPoint.START:
                     if from_lane_id != 1 or to_lane_id != 1:
                         _raise_lane_linkage_issue(checker_data, rule_uid, lane_link)
 

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -657,3 +657,14 @@ def get_connections_of_connecting_road(
                 linkage_connections.append(connection)
 
     return linkage_connections
+
+
+def get_road_hand_rule(road: etree._Element) -> models.TrafficHandRule:
+    rule = road.get("rule")
+
+    if rule is None:
+        # From standard:
+        # When this attribute is missing, RHT is assumed.
+        return models.TrafficHandRule.RHT
+    else:
+        return models.TrafficHandRule(rule)

--- a/qc_opendrive/checks/utils.py
+++ b/qc_opendrive/checks/utils.py
@@ -659,7 +659,7 @@ def get_connections_of_connecting_road(
     return linkage_connections
 
 
-def get_road_hand_rule(road: etree._Element) -> models.TrafficHandRule:
+def get_traffic_hand_rule_from_road(road: etree._Element) -> models.TrafficHandRule:
     rule = road.get("rule")
 
     if rule is None:
@@ -668,3 +668,12 @@ def get_road_hand_rule(road: etree._Element) -> models.TrafficHandRule:
         return models.TrafficHandRule.RHT
     else:
         return models.TrafficHandRule(rule)
+
+
+def get_lane_section_s_offset(lane_section: etree._Element) -> Union[None, float]:
+    s_offset = lane_section.get("sOffset")
+
+    if s_offset is None:
+        return None
+    else:
+        return float(s_offset)

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid.xodr
@@ -124,12 +124,12 @@
 	</road>
 
     <junction name="primary" id="100" type="default">
-        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
-            <laneLink from="1" to="1" />
+		<connection id="1" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="-1" to="-1" />
         </connection>
         <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
-            <laneLink from="-1" to="2" />
-        </connection>
+            <laneLink from="1" to="1" /> <!-- issue: lane link on opposite direction -->
+        </connection> <!-- issue: duplicated connection with pair incoming and connecting road-->
     </junction>
 
 </OpenDRIVE>

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid_LHT.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_invalid_LHT.xodr
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1" rule="LHT">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100" rule="LHT">
+		<link>
+			<predecessor elementType="road" elementId="1" contactPoint="end"/>
+			<successor elementType="road" elementId="3" contactPoint="start"/>
+		</link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1" rule="LHT">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+		<connection id="1" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="-1" to="-1" /> <!-- issue: lane link on opposite direction -->
+        </connection> <!-- issue: duplicated connection with pair incoming and connecting road-->
+    </junction>
+
+</OpenDRIVE>

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid.xodr
@@ -44,6 +44,10 @@
 		</lanes>
 	</road>
     <road name="B" length="10.0" id="2" junction="100">
+		<link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+			<successor elementType="road" elementId="3" contactPoint="start"/>
+		</link>
 		<planView>
 			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
 				<line />
@@ -57,6 +61,10 @@
 			<laneSection s="0.00000000000000e+00">
 				<left>
 					<lane id="1" type="driving">
+						<link>
+							<predecessor id="1" />
+							<successor id="1" />
+						</link>
 						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
 						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
 						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
@@ -70,6 +78,10 @@
 				</center>
 				<right>
 					<lane id="-1" type="driving">
+						<link>
+							<predecessor id="-1" />
+							<successor id="-1" />
+						</link>
 						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
 						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
 						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
@@ -120,10 +132,7 @@
 	</road>
 
     <junction name="primary" id="100" type="default">
-        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
-            <laneLink from="1" to="1" />
-        </connection>
-        <connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+        <connection id="1" incomingRoad="1" connectingRoad="2" contactPoint="start">
             <laneLink from="-1" to="-1" />
         </connection>
     </junction>

--- a/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid_LHT.xodr
+++ b/tests/data/junctions_connection_one_link_to_incoming/junctions_connection_one_link_to_incoming_valid_LHT.xodr
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+	<road name="A" length="10.0" id="1" junction="-1" rule="LHT">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="1.68150305747988e-04" y="-9.99989698737860e+00" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="B" length="10.0" id="2" junction="100" rule="LHT">
+		<link>
+			<predecessor elementType="road" elementId="1" contactPoint="end"/>
+			<successor elementType="road" elementId="3" contactPoint="start"/>
+		</link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1" rule="LHT">
+        <link>
+            <predecessor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="9.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+		<connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="1" to="1" />
+        </connection>
+		<connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -393,6 +393,20 @@ def test_junctions_connection_one_connection_element(
                 "/OpenDRIVE/junction/connection[2]/laneLink",
             ],
         ),
+        (
+            "valid_LHT",
+            0,
+            [],
+        ),
+        (
+            "invalid_LHT",
+            2,
+            [
+                "/OpenDRIVE/junction/connection[1]",
+                "/OpenDRIVE/junction/connection[2]",
+                "/OpenDRIVE/junction/connection[2]/laneLink",
+            ],
+        ),
     ],
 )
 def test_junctions_connection_one_link_to_incoming(


### PR DESCRIPTION
**Description**

This PR fixes the logic for the detection of the lane link direction to now consider the traffic hand rule.

**Main changes**

1. Update logic to use traffic hand on the lane link check
2. Update tests to fit the new implementation
3. Add utils to get road traffic hand rule

**How was the PR tested?**

1. Unit-test with some sample data. 

**Notes**
- Related to https://github.com/asam-ev/qc-opendrive/issues/10