### PR TITLE
Add implementation for rule 180

### DIFF
--- a/qc_opendrive/checks/semantic/__init__.py
+++ b/qc_opendrive/checks/semantic/__init__.py
@@ -22,3 +22,6 @@ from . import road_lane_link_new_lane_appear as road_lane_link_new_lane_appear
 from . import (
     junctions_connection_start_along_linkage as junctions_connection_start_along_linkage,
 )
+from . import (
+    junctions_connection_end_opposite_linkage as junctions_connection_end_opposite_linkage,
+)

--- a/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
@@ -1,0 +1,109 @@
+import logging
+
+from lxml import etree
+
+from qc_baselib import IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.semantic import semantic_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.7.0"
+
+
+def _raise_issue(
+    checker_data: models.CheckerData, rule_uid: str, connection: etree._Element
+):
+    issue_id = checker_data.result.register_issue(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        description=f"The value 'end' shall be used to indicate that the connecting road runs along the opposite direction of the linkage indicated in the element.",
+        level=IssueSeverity.ERROR,
+        rule_uid=rule_uid,
+    )
+    checker_data.result.add_xml_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        issue_id=issue_id,
+        xpath=checker_data.input_file_xml_root.getpath(connection),
+        description=f"Contact point 'end' not used on successor road connection.",
+    )
+
+
+def _check_junction_connection_end_opposite_linkage(
+    checker_data: models.CheckerData, rule_uid: str
+) -> None:
+    junctions = utils.get_junctions(checker_data.input_file_xml_root)
+    road_id_map = utils.get_road_id_map(checker_data.input_file_xml_root)
+
+    for junction in junctions:
+
+        connections = utils.get_connections_from_junction(junction)
+
+        for connection in connections:
+            contact_point = utils.get_contact_point_from_connection(connection)
+            if contact_point is None:
+                continue
+
+            if contact_point == models.ContactPoint.END:
+                connection_road_id = utils.get_connecting_road_id_from_connection(
+                    connection
+                )
+                if connection_road_id is None:
+                    continue
+
+                incoming_road_id = utils.get_incoming_road_id_from_connection(
+                    connection
+                )
+                if incoming_road_id is None:
+                    continue
+
+                connection_road = road_id_map.get(connection_road_id)
+                if connection_road is None:
+                    continue
+
+                successor_linkage = utils.get_road_linkage(
+                    connection_road, models.LinkageTag.SUCCESSOR
+                )
+                if successor_linkage is None:
+                    continue
+
+                if successor_linkage.id != incoming_road_id:
+                    _raise_issue(checker_data, rule_uid, connection)
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:xodr:1.7.0:junctions.connection.end_opposite_linkage
+
+    Description: The value "end" shall be used to indicate that the connecting
+    road runs along the opposite direction of the linkage indicated in the element.
+
+    Severity: ERROR
+
+    Version range: [1.7.0, )
+
+    Remark:
+        None
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/37
+    """
+    logging.info("Executing junctions.connection.end_opposite_linkage check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=semantic_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="junctions.connection.end_opposite_linkage",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    _check_junction_connection_end_opposite_linkage(checker_data, rule_uid)

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -20,6 +20,7 @@ from qc_opendrive.checks.semantic import (
     junctions_connection_one_connection_element,
     junctions_connection_one_link_to_incoming,
     junctions_connection_start_along_linkage,
+    junctions_connection_end_opposite_linkage,
 )
 
 
@@ -49,6 +50,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         junctions_connection_one_connection_element.check_rule,
         junctions_connection_one_link_to_incoming.check_rule,
         junctions_connection_start_along_linkage.check_rule,
+        junctions_connection_end_opposite_linkage.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -744,3 +744,34 @@ def test_junction_connection_start_along_linkage(
     launch_main(monkeypatch)
     check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
     cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        (
+            "invalid",
+            1,
+            [
+                "/OpenDRIVE/junction/connection[1]",
+            ],
+        ),
+    ],
+)
+def test_junction_connection_end_opposite_linkage(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/junction_connection_linkage/"
+    target_file_name = f"junction_connection_linkage_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.7.0:junctions.connection.end_opposite_linkage"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()


### PR DESCRIPTION
**Description**

This PR adds the implementation for checking if the `end` contact point is properly used as on connections to `successor` roads, indicating the roads run in the opposite direction then the `laneLink` elements inside. 
**Main changes**

1. Add rule implementation
2. Add tests for rule

**How was the PR tested?**

1. Unit-test with some sample data.
2. Tested with some OpenDrive examples.

**Notes**
- Related to #37 