### PR TITLE
Add normalized range rule

### DIFF
--- a/qc_opendrive/checks/geometry/__init__.py
+++ b/qc_opendrive/checks/geometry/__init__.py
@@ -6,3 +6,6 @@ from . import (
 from . import (
     road_geometry_parampoly3_arclength_range as road_geometry_parampoly3_arclength_range,
 )
+from . import (
+    road_geometry_parampoly3_normalized_range as road_geometry_parampoly3_normalized_range,
+)

--- a/qc_opendrive/checks/geometry/geometry_checker.py
+++ b/qc_opendrive/checks/geometry/geometry_checker.py
@@ -12,6 +12,7 @@ from qc_opendrive.checks.geometry import (
     road_geometry_param_poly3_length_match,
     road_lane_border_overlap_with_inner_lanes,
     road_geometry_parampoly3_arclength_range,
+    road_geometry_parampoly3_normalized_range,
 )
 
 
@@ -33,6 +34,7 @@ def run_checks(config: Configuration, result: Result) -> None:
         road_geometry_param_poly3_length_match.check_rule,
         road_lane_border_overlap_with_inner_lanes.check_rule,
         road_geometry_parampoly3_arclength_range.check_rule,
+        road_geometry_parampoly3_normalized_range.check_rule,
     ]
 
     checker_data = models.CheckerData(

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
@@ -1,0 +1,87 @@
+import logging
+
+import numpy as np
+from scipy.integrate import quad
+
+from qc_baselib import IssueSeverity
+
+from qc_opendrive import constants
+from qc_opendrive.checks import utils, models
+from qc_opendrive.checks.geometry import geometry_constants
+
+RULE_INITIAL_SUPPORTED_SCHEMA_VERSION = "1.7.0"
+TOLERANCE_THRESHOLD = 0.001
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:xodr:1.7.0:road.geometry.parampoly3.normalized_range
+
+    Description: If @prange="normalized", p shall be chosen in [0, 1].
+
+    Severity: ERROR
+
+    Version range: [1.7.0, )
+
+    Remark:
+        This check currently relies on the accuracy of the scipy.integrate.quad method.
+        The estimated absolute error of the numerical integration is included in
+        the issue description message.
+
+    More info at
+        - https://github.com/asam-ev/qc-opendrive/issues/39
+    """
+    logging.info("Executing road.geometry.parampoly3.normalized_range check.")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=geometry_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="xodr",
+        definition_setting=RULE_INITIAL_SUPPORTED_SCHEMA_VERSION,
+        rule_full_name="road.geometry.parampoly3.normalized_range",
+    )
+
+    if checker_data.schema_version < RULE_INITIAL_SUPPORTED_SCHEMA_VERSION:
+        logging.info(
+            f"Schema version {checker_data.schema_version} not supported. Skipping rule."
+        )
+        return
+
+    geometry_elements = checker_data.input_file_xml_root.xpath("//geometry")
+
+    for geometry in geometry_elements:
+        length = utils.get_length_from_geometry(geometry)
+        if length is None:
+            continue
+
+        param_poly3 = utils.get_normalized_param_poly3_from_geometry(geometry)
+
+        if param_poly3 is None:
+            continue
+
+        u = utils.poly3_to_polynomial(param_poly3.u)
+        v = utils.poly3_to_polynomial(param_poly3.v)
+        du = u.deriv()
+        dv = v.deriv()
+
+        integral_length, estimated_error = quad(
+            utils.arc_length_integrand, 0.0, 1, args=(du, dv)
+        )
+
+        if np.abs(integral_length - length) > TOLERANCE_THRESHOLD:
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=geometry_constants.CHECKER_ID,
+                description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
+                level=IssueSeverity.ERROR,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=geometry_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=checker_data.input_file_xml_root.getpath(geometry),
+                description=f"",
+            )

--- a/tests/test_geometry_checks.py
+++ b/tests/test_geometry_checks.py
@@ -139,3 +139,38 @@ def test_road_geometry_parampoly3_arclength_range(
     launch_main(monkeypatch)
     check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
     cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        (
+            "valid",
+            0,
+            [],
+        ),
+        (
+            "invalid",
+            1,
+            [
+                "/OpenDRIVE/road/planView/geometry[2]",
+            ],
+        ),
+    ],
+)
+def test_road_geometry_param_poly3_normalized_range(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/road_geometry_param_poly3_length_match/"
+    target_file_name = f"road_geometry_param_poly3_length_match_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.7.0:road.geometry.parampoly3.normalized_range"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()


### PR DESCRIPTION
**Description**

This PR adds the checker rule for the `<paramPoly3>` element when `pRange="normalized"`. The check verify if the length matches within the range `[0, 1]`.

**Main changes**

1. Add check for normalized poly3
2. Add tests for check

**How was the PR tested?**

1. Unit-test with some sample data.

**Notes**
- Related to issue #39