### PR TITLE
Fix appearing lane logic to take into account road contact point

### DIFF
--- a/qc_opendrive/base/utils.py
+++ b/qc_opendrive/base/utils.py
@@ -745,29 +745,6 @@ def get_s_coordinate_from_lane_section(
         return float(s_coordinate)
 
 
-def calculate_road_lane_sections_length(road: etree._ElementTree) -> Dict[int, float]:
-    lane_sections = get_lane_sections(road)
-    lane_section_lengths = {}
-
-    for index in range(len(lane_sections)):
-        current_lane_section = lane_sections[index]
-
-        if index < len(lane_sections) - 1:
-            next_lane_section = lane_sections[index + 1]
-            lane_section_length = get_s_coordinate_from_lane_section(
-                next_lane_section
-            ) - get_s_coordinate_from_lane_section(current_lane_section)
-        else:
-            road_length = get_road_length(road)
-            lane_section_length = road_length - get_s_coordinate_from_lane_section(
-                current_lane_section
-            )
-
-        lane_section_lengths[index] = lane_section_length
-
-    return lane_section_lengths
-
-
 def get_borders_from_lane(lane: etree._ElementTree) -> List[models.OffsetPoly3]:
     border_list = []
     for border in lane.iter("border"):

--- a/qc_opendrive/base/utils.py
+++ b/qc_opendrive/base/utils.py
@@ -745,6 +745,29 @@ def get_s_coordinate_from_lane_section(
         return float(s_coordinate)
 
 
+def calculate_road_lane_sections_length(road: etree._ElementTree) -> Dict[int, float]:
+    lane_sections = get_lane_sections(road)
+    lane_section_lengths = {}
+
+    for index in range(len(lane_sections)):
+        current_lane_section = lane_sections[index]
+
+        if index < len(lane_sections) - 1:
+            next_lane_section = lane_sections[index + 1]
+            lane_section_length = get_s_coordinate_from_lane_section(
+                next_lane_section
+            ) - get_s_coordinate_from_lane_section(current_lane_section)
+        else:
+            road_length = get_road_length(road)
+            lane_section_length = road_length - get_s_coordinate_from_lane_section(
+                current_lane_section
+            )
+
+        lane_section_lengths[index] = lane_section_length
+
+    return lane_section_lengths
+
+
 def get_borders_from_lane(lane: etree._ElementTree) -> List[models.OffsetPoly3]:
     border_list = []
     for border in lane.iter("border"):

--- a/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
@@ -151,9 +151,9 @@ def _check_appearing_successor_road(
 
     next_lane_section_length = 0.0
     lane_sections_length = utils.calculate_road_lane_sections_length(successor_road)
-    if successor_linkage == models.ContactPoint.START:
+    if successor_linkage.contact_point == models.ContactPoint.START:
         next_lane_section_length = lane_sections_length[0]
-    elif successor_linkage == models.ContactPoint.END:
+    elif successor_linkage.contact_point == models.ContactPoint.END:
         next_lane_section_length = lane_sections_length[len(lane_sections_length) - 1]
 
     _check_successor_with_width_zero_between_lane_sections(

--- a/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
@@ -98,16 +98,14 @@ def _check_successor_with_width_zero_between_lane_sections(
 def _check_appearing_successor_with_width_zero_on_road(
     checker_data: models.CheckerData, rule_uid: str, road: etree._ElementTree
 ) -> None:
-    lane_sections = utils.get_lane_sections(road)
+    lane_sections = utils.get_sorted_lane_sections_with_length_from_road(road)
 
     if len(lane_sections) < 2:
         return
 
-    lane_sections_length = utils.calculate_road_lane_sections_length(road)
-
     for index in range(len(lane_sections) - 1):
-        current_lane_section = lane_sections[index]
-        next_lane_section = lane_sections[index + 1]
+        current_lane_section = lane_sections[index].lane_section
+        next_lane_section = lane_sections[index + 1].lane_section
 
         _check_successor_with_width_zero_between_lane_sections(
             checker_data,
@@ -115,7 +113,7 @@ def _check_appearing_successor_with_width_zero_on_road(
             current_lane_section,
             next_lane_section,
             models.ContactPoint.START,
-            lane_sections_length[index + 1],
+            lane_sections[index + 1].length,
         )
 
 
@@ -150,11 +148,11 @@ def _check_appearing_successor_road(
         return
 
     next_lane_section_length = 0.0
-    lane_sections_length = utils.calculate_road_lane_sections_length(successor_road)
+    lane_sections = utils.get_sorted_lane_sections_with_length_from_road(successor_road)
     if successor_linkage.contact_point == models.ContactPoint.START:
-        next_lane_section_length = lane_sections_length[0]
+        next_lane_section_length = lane_sections[0].length
     elif successor_linkage.contact_point == models.ContactPoint.END:
-        next_lane_section_length = lane_sections_length[len(lane_sections_length) - 1]
+        next_lane_section_length = lane_sections[len(lane_sections) - 1].length
 
     _check_successor_with_width_zero_between_lane_sections(
         checker_data,

--- a/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_both_start_contact_point_invalid.xodr
+++ b/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_both_start_contact_point_invalid.xodr
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+    <road name="B" length="10.0" id="2" junction="-1">
+		<link>
+			<predecessor elementType="road" elementId="3" contactPoint="start"/>
+		</link>
+		<planView>
+            <geometry s="0.00000000000000e+00" x="0.05" y="19.95" hdg="-1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+                            <predecessor id="-1"/>
+                            <predecessor id="-2"/>
+                        </link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<successor id="1"/>
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="start"/>
+        </link>
+		<planView>
+            <geometry s="0.00000000000000e+00" x="0.05" y="19.95" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+                            <predecessor id="-1"/>
+                        </link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+                    <lane id="-1" type="driving">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+                    <lane id="-2" type="driving">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+						<width sOffset="0.00000000000000e+00" a="0.00000000000000e+00" b="0.30000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane> <!-- width starts in 0.0 -->
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+</OpenDRIVE>

--- a/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_invalid.xodr
+++ b/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_invalid.xodr
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+    <road name="B" length="10.0" id="2" junction="100">
+		<link>
+			<successor elementType="road" elementId="3" contactPoint="end"/>
+		</link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<successor id="1"/>
+							<successor id="2"/>
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="19.95" hdg="-1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="2" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="-0.30000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane> <!-- width ends in 0.0 -->
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+                    <lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+            <laneLink from="-1" to="1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_valid.xodr
+++ b/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_valid.xodr
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="" version="1.00" date="26.06.2024 15:35:45" north="3.50860889879943e+01" south="-1.49139110120057e+01" east="3.67393953684785e+01" west="-1.32606046315215e+01" vendor="">
+		<userData code="settings" value="" />
+	</header>
+
+    <road name="B" length="10.0" id="2" junction="100">
+		<link>
+			<successor elementType="road" elementId="3" contactPoint="end"/>
+		</link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.03" y="-0.05" hdg="1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<successor id="1"/>
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+    <road name="C" length="10.0" id="3" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="100"/>
+        </link>
+		<planView>
+			<geometry s="0.00000000000000e+00" x="0.05" y="19.95" hdg="-1.57080404096212e+00" length="10.0">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="0.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="2" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="-0.30000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane> <!-- width ends in 0.0 -->
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+                    <lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.00000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+
+    <junction name="primary" id="100" type="default">
+        <connection id="1" incomingRoad="3" connectingRoad="2" contactPoint="end">
+            <laneLink from="-1" to="1" />
+        </connection>
+    </junction>
+
+</OpenDRIVE>

--- a/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_valid_example.xodr
+++ b/tests/data/road_lane_link_new_lane_appear/road_lane_link_new_lane_appear_end_contact_point_valid_example.xodr
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="6" name="a38b7dae-e9c1-48ef-9b6b-7172e50f60d4" version="0.13" date="2024-06-25T10:22:09" north="1.3912618695e+03" south="-1.0009308948e+03" east="7.8002782833e+02" west="-7.3600373395e+02" vendor="AnteMotion SRL, all rights reserved">
+    </header>
+    <road name="Road 28645916416" length="1.1831080978e+01" id="228" junction="-1" rule="RHT">
+        <link>
+            <successor elementId="767" elementType="road" contactPoint="end"/>
+        </link>
+        <type s="0.0000000000e+00" type="town" country="DE">
+            <speed max="50" unit="km/h"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000e+00" x="3.4496087102e+02" y="-7.9719449340e+02" hdg="2.2676196847e+00" length="11.831080978158123">
+                <spiral curvStart="8.2516208705e-04" curvEnd="3.5757614245e-04"/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000e+00" a="5.5112000000e+02" b="2.0883946276e-02" c="7.8366892662e-04" d="-3.4282376283e-05"/>
+        </elevationProfile>
+        <lanes>
+            <laneOffset s="0.0000000000e+00" a="4.7596835561e-03" b="5.2385796159e-03" c="0.0000000000e+00" d="0.0000000000e+00"/>
+            <laneSection s="0.0000000000e+00" singleSide="false">
+                <left>
+                    <lane type="connectingRamp" id="3">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="2.8615171966e+00" b="6.7763895637e-03" c="0.0000000000e+00" d="0.0000000000e+00"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                    <lane type="onRamp" id="2">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="3.6746513316e+00" b="2.0310005367e-03" c="0.0000000000e+00" d="0.0000000000e+00"/>
+                        <roadMark sOffset="0.0000000000e+00" type="solid" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="none" height="1.0000000000e-03"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                    <lane type="connectingRamp" id="1">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="3.4558218724e+00" b="-7.2695802826e-03" c="0.0000000000e+00" d="0.0000000000e+00"/>
+                        <roadMark sOffset="0.0000000000e+00" type="broken" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="both" height="1.0000000000e-03"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane type="driving" id="0">
+                        <roadMark sOffset="0.0000000000e+00" type="solid" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="none" height="1.0000000000e-03"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+        <signals/>
+    </road>
+
+    <road name="Road 91559732330" length="3.4707652757e+01" id="767" junction="-1" rule="RHT">
+        <link>
+            <successor elementId="228" elementType="road" contactPoint="end"/>
+        </link>
+        <type s="0.0000000000e+00" type="town" country="DE">
+            <speed max="50" unit="km/h"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000e+00" x="3.1446773806e+02" y="-7.6204174497e+02" hdg="-8.3250753433e-01" length="19.69984191892492">
+                <spiral curvStart="-1.2663537281e-03" curvEnd="-9.9932007314e-04"/>
+            </geometry>
+            <geometry s="1.9699841919e+01" x="3.2755606082e+02" y="-7.7676463387e+02" hdg="-8.5482424219e-01" length="15.0078108377385">
+                <spiral curvStart="-9.9932007315e-04" curvEnd="-6.2012874804e-04"/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+            <elevation s="0.0000000000e+00" a="5.5229000000e+02" b="-2.5132709718e-02" c="-4.0303837549e-05" d="1.4748749937e-06"/>
+            <elevation s="1.9720800744e+01" a="5.5179000000e+02" b="-2.5001576796e-02" c="6.4690539257e-05" d="-2.9217309043e-06"/>
+        </elevationProfile>
+        <lanes>
+            <laneOffset s="0.0000000000e+00" a="-1.5534314973e-01" b="3.6293954388e-03" c="-2.4842789301e-05" d="-1.0380290551e-06"/>
+            <laneOffset s="5.3394692606e+00" a="-1.3683038757e-01" b="3.2753184059e-03" c="-1.5972067709e-05" d="-1.4342840631e-06"/>
+            <laneOffset s="1.2511721563e+01" a="-1.1468977805e-01" b="2.8248631137e-03" c="-2.3677353999e-05" d="-9.8788688989e-07"/>
+            <laneOffset s="1.9699843898e+01" a="-9.5974609021e-02" b="2.3313419920e-03" c="-2.1175662382e-05" d="-2.5501055213e-07"/>
+            <laneOffset s="3.0023578150e+01" a="-7.4443932802e-02" b="1.8125814869e-03" c="-4.2130697849e-05" d="1.3651059810e-06"/>
+            <laneSection s="0.0000000000e+00" singleSide="false">
+                <center>
+                    <lane type="driving" id="0">
+                        <roadMark sOffset="0.0000000000e+00" type="solid" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="none" height="1.0000000000e-03"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane type="connectingRamp" id="-1">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="3.3224389426e+00" b="-2.0436674263e-03" c="1.4760240835e-05" d="1.4665862810e-05"/>
+                        <width sOffset="5.3394692606e+00" a="3.3141802102e+00" b="-6.3167546823e-04" c="1.6240553782e-05" d="2.5836148571e-06"/>
+                        <width sOffset="1.2511721563e+01" a="3.3114383309e+00" b="0.0000000000e+00" c="3.1060146187e-04" d="-1.7298677121e-05"/>
+                        <width sOffset="1.9699843898e+01" a="3.3210620347e+00" b="1.7838612362e-03" c="1.4908835139e-04" d="-4.4161794855e-06"/>
+                        <width sOffset="3.0023578150e+01" a="3.3505087895e+00" b="3.4501358185e-03" c="2.0214329695e-04" d="-1.2549622848e-05"/>
+                        <roadMark sOffset="0.0000000000e+00" type="broken" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="both" height="1.0000000000e-03"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                    <lane type="onRamp" id="-2">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="3.6574507953e+00" b="5.6730628651e-03" c="-8.2819046092e-05" d="-7.6102005547e-06"/>
+                        <width sOffset="5.3394692606e+00" a="3.6842222898e+00" b="4.1377444629e-03" c="3.8795324388e-05" d="-1.8403983375e-05"/>
+                        <width sOffset="1.2511721563e+01" a="3.7091047787e+00" b="1.8540750329e-03" c="1.1994772877e-05" d="-1.3073672764e-05"/>
+                        <width sOffset="1.9699843898e+01" a="3.7181962438e+00" b="0.0000000000e+00" c="-1.0137520191e-04" d="2.6251413862e-06"/>
+                        <width sOffset="3.0023578150e+01" a="3.7102801653e+00" b="-1.2537826067e-03" c="-4.0813633990e-04" d="3.1406160849e-05"/>
+                        <roadMark sOffset="0.0000000000e+00" type="solid" weight="standard" color="white" material="standard" width="1.5000000000e-01" laneChange="none" height="1.0000000000e-03"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                    <lane type="connectingRamp" id="-3">
+                        <link>
+                            <successor id="3"/>
+                        </link>
+                        <width sOffset="0.0000000000e+00" a="-0.0000000000e+00" b="0.0000000000e+00" c="7.0950072093e-03" d="-4.3918070835e-04"/>
+                        <width sOffset="5.3394692606e+00" a="1.3542261362e-01" b="3.8204109423e-02" c="1.1380162948e-02" d="-6.4795525344e-04"/>
+                        <width sOffset="1.2511721563e+01" a="7.5577876985e-01" b="1.0145211588e-01" c="6.9100107734e-03" d="-5.5037405088e-04"/>
+                        <width sOffset="1.9699843898e+01" a="1.6376520153e+00" b="1.1548012135e-01" c="3.7859789577e-03" d="-4.3398155868e-04"/>
+                        <width sOffset="3.0023578150e+01" a="2.7558366218e+00" b="5.4890404478e-02" c="-1.9223147341e-03" d="-2.8297336164e-04"/>
+                        <speed sOffset="0.0000000000e+00" max="5.0000000000e+01" unit="km/h"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals/>
+    </road>
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -778,6 +778,40 @@ def test_road_lane_link_new_lane_appear_inside_junction(
             "invalid",
             1,
             [
+                "/OpenDRIVE/road[1]/lanes/laneSection/right/lane",
+                "/OpenDRIVE/road[2]/lanes/laneSection/left/lane[2]",
+            ],
+        ),
+    ],
+)
+def test_road_lane_link_new_lane_appear_junction(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/road_lane_link_new_lane_appear/"
+    target_file_name = (
+        f"road_lane_link_new_lane_appear_end_contact_point_{target_file}.xodr"
+    )
+    rule_uid = "asam.net:xodr:1.4.0:road.lane.link.new_lane_appear"
+    issue_severity = IssueSeverity.ERROR
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_issues(rule_uid, issue_count, issue_xpath, issue_severity)
+    cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
+        ("valid", 0, []),
+        (
+            "invalid",
+            1,
+            [
                 "/OpenDRIVE/junction/connection[2]",
             ],
         ),

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -684,6 +684,14 @@ def test_road_lane_link_zero_width_at_end_inside_junction(
                 "/OpenDRIVE/road/lanes/laneSection[2]/right/lane[2]",
             ],
         ),
+        (
+            "both_start_contact_point_invalid",
+            1,
+            [
+                "/OpenDRIVE/road[1]/lanes/laneSection/left/lane",
+                "/OpenDRIVE/road[2]/lanes/laneSection/right/lane[2]",
+            ],
+        ),
     ],
 )
 def test_road_lane_link_new_lane_appear(

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -774,6 +774,7 @@ def test_road_lane_link_new_lane_appear_inside_junction(
     "target_file,issue_count,issue_xpath",
     [
         ("valid", 0, []),
+        ("valid_example", 0, []),
         (
             "invalid",
             1,

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -784,7 +784,7 @@ def test_road_lane_link_new_lane_appear_inside_junction(
         ),
     ],
 )
-def test_road_lane_link_new_lane_appear_junction(
+def test_road_lane_link_new_lane_appear_end_contact_point(
     target_file: str,
     issue_count: int,
     issue_xpath: List[str],


### PR DESCRIPTION
**Description**

This PR addresses an issue with the lane appearing implementation, where the appearing lane in a successor road, would only be taken into account if the contact point was start in the road linkage. Now, the road linkage is used to decide if we need to evaluate the start or the end of a lane width.

**Main changes**

1. Update appearing lane to take into account road linkage contact point
2. Add tests for update

**How was the PR tested?**

1. Unit-test with new examples where road successor is the end of a road where the road ends in zero. This triggered the rule as intended.

**Notes**
- https://github.com/asam-ev/qc-opendrive/issues/61