### PR TITLE
Ignore namespace on XML file parsing

### DIFF
--- a/qc_opendrive/base/utils.py
+++ b/qc_opendrive/base/utils.py
@@ -1,11 +1,22 @@
-from typing import List, Dict, Union
-
-from lxml import etree
-from qc_opendrive.base import models
+import re
 import numpy as np
+from io import BytesIO
+from typing import List, Dict, Union
+from lxml import etree
 
+from qc_opendrive.base import models
 
 EPSILON = 1.0e-6
+
+
+def get_root(path: str) -> etree._ElementTree:
+    with open(path, "rb") as raw_file:
+        xml_string = raw_file.read().decode()
+
+        if "xmlns" in xml_string:
+            xml_string = re.sub(' xmlns="[^"]+"', "", xml_string)
+
+        return etree.parse(BytesIO(xml_string.encode()))
 
 
 def get_lanes(root: etree._ElementTree) -> List[etree._ElementTree]:

--- a/qc_opendrive/checks/geometry/geometry_checker.py
+++ b/qc_opendrive/checks/geometry/geometry_checker.py
@@ -19,7 +19,7 @@ from qc_opendrive.checks.geometry import (
 def run_checks(config: Configuration, result: Result) -> None:
     logging.info("Executing geometry checks")
 
-    root = etree.parse(config.get_config_param("InputFile"))
+    root = utils.get_root(config.get_config_param("InputFile"))
 
     result.register_checker(
         checker_bundle_name=constants.BUNDLE_NAME,

--- a/qc_opendrive/checks/performance/performance_checker.py
+++ b/qc_opendrive/checks/performance/performance_checker.py
@@ -16,7 +16,7 @@ from qc_opendrive.checks.performance import (
 def run_checks(config: Configuration, result: Result) -> None:
     logging.info("Executing performance checks")
 
-    root = etree.parse(config.get_config_param("InputFile"))
+    root = utils.get_root(config.get_config_param("InputFile"))
 
     result.register_checker(
         checker_bundle_name=constants.BUNDLE_NAME,

--- a/qc_opendrive/checks/semantic/semantic_checker.py
+++ b/qc_opendrive/checks/semantic/semantic_checker.py
@@ -27,7 +27,7 @@ from qc_opendrive.checks.semantic import (
 def run_checks(config: Configuration, result: Result) -> None:
     logging.info("Executing semantic checks")
 
-    root = etree.parse(config.get_config_param("InputFile"))
+    root = utils.get_root(config.get_config_param("InputFile"))
 
     result.register_checker(
         checker_bundle_name=constants.BUNDLE_NAME,

--- a/tests/data/utils/namespace.xodr
+++ b/tests/data/utils/namespace.xodr
@@ -1,0 +1,151 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE xmlns="http://code.asam.net/simulation/standard/opendrive_schema" >
+  <header revMajor="1" revMinor="8" name="" version="1.00" date="Wed Aug  2 09:16:10 2023"
+    north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00"
+    west="0.0000000000000000e+00">
+  </header>
+  <road name="" length="1.0000000000000000e+02" id="1" junction="-1" rule="RHT">
+    <link>
+    </link>
+    <planView>
+      <geometry s="0.0000000000000000e+00" x="1.1970260013222610e+02" y="9.1508118250189384e+01"
+        hdg="5.1105731189804682e-01" length="1.0000000000000000e+02">
+        <line />
+      </geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00"
+        c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <successor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <successor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <successor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <predecessor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="50.0000000000000000e+00">
+        <left>
+          <lane id="3" type="sidewalk">
+            <link>
+              <predecessor id="3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="2" type="border">
+            <link>
+              <predecessor id="2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="1.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="1" type="driving">
+            <link>
+              <predecessor id="1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="4.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </left>
+        <center>
+          <lane id="0">
+            <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard"
+              color="standard" width="1.2000000000000000e-01" laneChange="both"
+              height="1.9999999552965164e-02">
+              <type name="broken" width="1.2000000000000000e-01">
+                <line length="3.0000000000000000e+00" space="6.0000000000000000e+00"
+                  tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution"
+                  width="1.2000000000000000e-01" />
+              </type>
+            </roadMark>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving">
+            <link>
+              <predecessor id="-1" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-2" type="border">
+            <link>
+              <predecessor id="-2" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+          <lane id="-3" type="sidewalk">
+            <link>
+              <predecessor id="-3" />
+            </link>
+            <width sOffset="0.0000000000000000e+00" a="3.0000000000000000e+00"
+              b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00" />
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <objects>
+    </objects>
+    <signals>
+    </signals>
+    <surface>
+    </surface>
+  </road>
+</OpenDRIVE>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,13 +3,22 @@ from lxml import etree
 from qc_opendrive.base import utils
 
 
+def test_get_root() -> None:
+    # file containing namespace
+    root = utils.get_root("tests/data/utils/namespace.xodr")
+    assert type(root) == etree._ElementTree
+    # file does not contain namespace
+    root = utils.get_root("tests/data/utils/Ex_Bidirectional_Junction.xodr")
+    assert type(root) == etree._ElementTree
+
+
 def test_get_road_id_map() -> None:
-    root = etree.parse("tests/data/utils/Ex_Bidirectional_Junction.xodr")
+    root = utils.get_root("tests/data/utils/Ex_Bidirectional_Junction.xodr")
     road_id_map = utils.get_road_id_map(root)
     assert len(road_id_map) == 6
 
 
 def test_get_junction_id_map() -> None:
-    root = etree.parse("tests/data/utils/Ex_Bidirectional_Junction.xodr")
+    root = utils.get_root("tests/data/utils/Ex_Bidirectional_Junction.xodr")
     junction_id_map = utils.get_junction_id_map(root)
     assert len(junction_id_map) == 1


### PR DESCRIPTION
**Description**

This PR adds a helper method to get the root of a OpenDrive XML file. The method removes the namespace that can be added to the top of the OpenDrive definition in order to avoid breaking the tags references in the file.

**Main changes**

1. Add `get_root` method to utils with namespace removal
2. Update checkers to use the new function instead of directly parsing
3. Add tests for new function

**How was the PR tested?**

1. Unit-test with some sample data.
2. Execution of all uni-tests with new approach, all passed as intended.

**Notes**
- We can use the same approach on OpenScenario checker.