### PR TITLE
Add inertial point to horizontal smoothness check

### DIFF
--- a/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
+++ b/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
@@ -117,7 +117,7 @@ def _raise_lane_linkage_gap_issue(
             x=inertial_point.x,
             y=inertial_point.y,
             z=inertial_point.z,
-            description="Lane reference point",
+            description="Next lane middle reference point",
         )
 
 

--- a/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
+++ b/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
@@ -79,6 +79,9 @@ def _raise_lane_linkage_gap_issue(
     rule_uid: str,
     previous_lane: etree._Element,
     current_lane: etree._Element,
+    current_road: etree._ElementTree,
+    current_road_s: float,
+    current_road_t: float,
 ) -> None:
     issue_id = checker_data.result.register_issue(
         checker_bundle_name=constants.BUNDLE_NAME,
@@ -102,6 +105,20 @@ def _raise_lane_linkage_gap_issue(
         xpath=checker_data.input_file_xml_root.getpath(current_lane),
         description=f"Next lane element",
     )
+
+    inertial_point = utils.get_point_xyz_from_road(
+        road=current_road, s=current_road_s, t=current_road_t, h=0
+    )
+    if inertial_point is not None:
+        checker_data.result.add_inertial_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=smoothness_constants.CHECKER_ID,
+            issue_id=issue_id,
+            x=inertial_point.x,
+            y=inertial_point.y,
+            z=inertial_point.z,
+            description="Lane reference point",
+        )
 
 
 def _check_geometries_gap(
@@ -180,7 +197,7 @@ def _compute_inner_point(
     road_s: float,
 ) -> Union[None, models.Point3D]:
     sign = -1 if lane_id < 0 else 1
-    current_lane_t = current_lane_t = lanes_outer_points.get(lane_id - 1 * sign)
+    current_lane_t = lanes_outer_points.get(lane_id - 1 * sign)
     if current_lane_t is None:
         return None
     return utils.get_point_xyz_from_road(road=road, s=road_s, t=current_lane_t, h=0)
@@ -292,11 +309,18 @@ def _validate_same_road_lane_successors(
                 if utils.get_lane_id(next_lane) == next_lane_id
             ]
             if len(next_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(next_lane_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     lane,
                     next_lane[0],
+                    current_road=road,
+                    current_road_s=successor_road_s,
+                    current_road_t=current_road_t,
                 )
 
     elif len(successors) == 2:
@@ -320,11 +344,18 @@ def _validate_same_road_lane_successors(
                 if utils.get_lane_id(next_lane) == bottom_successor_id
             ]
             if len(next_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(bottom_successor_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     lane,
                     next_lane[0],
+                    current_road=road,
+                    current_road_s=successor_road_s,
+                    current_road_t=current_road_t,
                 )
 
         if not _equal_inner_border_points(
@@ -342,11 +373,18 @@ def _validate_same_road_lane_successors(
                 if utils.get_lane_id(next_lane) == upper_successor_id
             ]
             if len(next_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(upper_successor_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     lane,
                     next_lane[0],
+                    current_road=road,
+                    current_road_s=successor_road_s,
+                    current_road_t=current_road_t,
                 )
 
     else:
@@ -357,11 +395,18 @@ def _validate_same_road_lane_successors(
                 if utils.get_lane_id(next_lane) == extra_lane_id
             ]
             if len(next_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(extra_lane_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     lane,
                     next_lane[0],
+                    current_road=road,
+                    current_road_s=successor_road_s,
+                    current_road_t=current_road_t,
                 )
 
 
@@ -405,11 +450,18 @@ def _validate_same_road_lane_predecessors(
                 if utils.get_lane_id(prev_lane) == prev_lane_id
             ]
             if len(prev_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(prev_lane_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     prev_lane[0],
                     lane,
+                    current_road=road,
+                    current_road_s=current_road_s,
+                    current_road_t=current_road_t,
                 )
 
     elif len(predecessors) == 2:
@@ -433,11 +485,18 @@ def _validate_same_road_lane_predecessors(
                 if utils.get_lane_id(prev_lane) == upper_prev_id
             ]
             if len(prev_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(upper_prev_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     prev_lane[0],
                     lane,
+                    current_road=road,
+                    current_road_s=current_road_s,
+                    current_road_t=current_road_t,
                 )
 
         if not _equal_inner_border_points(
@@ -455,11 +514,18 @@ def _validate_same_road_lane_predecessors(
                 if utils.get_lane_id(prev_lane) == bottom_prev_id
             ]
             if len(prev_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(bottom_prev_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     prev_lane[0],
                     lane,
+                    current_road=road,
+                    current_road_s=current_road_s,
+                    current_road_t=current_road_t,
                 )
 
     else:
@@ -470,11 +536,18 @@ def _validate_same_road_lane_predecessors(
                 if utils.get_lane_id(prev_lane) == extra_lane_id
             ]
             if len(prev_lane) == 1:
+                current_road_t = (
+                    current_outer_points.get(lane_id)
+                    + current_outer_points.get(extra_lane_id)
+                ) / 2
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     prev_lane[0],
                     lane,
+                    current_road=road,
+                    current_road_s=current_road_s,
+                    current_road_t=current_road_t,
                 )
 
 
@@ -719,19 +792,31 @@ def _validate_inter_road_smoothness(
                     for target_lane in target_lanes
                     if utils.get_lane_id(target_lane) == conn_lane_id
                 )
+                sign = -1 if conn_lane_id < 0 else 1
+                target_road_t = (
+                    target_lanes_outer_points.get(conn_lane_id)
+                    + target_lanes_outer_points.get(conn_lane_id - 1 * sign)
+                ) / 2
                 if road_relation == models.LinkageTag.PREDECESSOR:
                     _raise_lane_linkage_gap_issue(
                         checker_data,
                         rule_uid,
                         target_lane,
                         lane,
+                        current_road=target_road,
+                        current_road_s=target_s,
+                        current_road_t=target_road_t,
                     )
+
                 elif road_relation == models.LinkageTag.SUCCESSOR:
                     _raise_lane_linkage_gap_issue(
                         checker_data,
                         rule_uid,
                         lane,
                         target_lane,
+                        current_road=target_road,
+                        current_road_s=target_s,
+                        current_road_t=target_road_t,
                     )
 
 
@@ -888,12 +973,20 @@ def _validate_junction_connection_gaps(
                 for target_lane in target_lanes
                 if utils.get_lane_id(target_lane) == to_id
             )
+            sign = -1 if to_id < 0 else 1
+            target_road_t = (
+                target_lanes_outer_points.get(to_id)
+                + target_lanes_outer_points.get(to_id - 1 * sign)
+            ) / 2
             if road_relation == models.LinkageTag.PREDECESSOR:
                 _raise_lane_linkage_gap_issue(
                     checker_data,
                     rule_uid,
                     from_lane,
                     target_lane,
+                    current_road=target_road,
+                    current_road_s=target_s,
+                    current_road_t=target_road_t,
                 )
             elif road_relation == models.LinkageTag.SUCCESSOR:
                 _raise_lane_linkage_gap_issue(
@@ -901,6 +994,9 @@ def _validate_junction_connection_gaps(
                     rule_uid,
                     from_lane,
                     target_lane,
+                    current_road=target_road,
+                    current_road_s=target_s,
+                    current_road_t=target_road_t,
                 )
 
 


### PR DESCRIPTION
**Description**

This PR adds a inertial point as reference to lane gap issues raised. 

The current inertial point added is the middle point on the edge for the successor lane (next lane) in the lane link relation, where the relation happens.

**Main changes**

1. Add inertial point to lane gap issues

**How was the PR tested?**

1. Unit-test.
2. Tested some OpenDrive files with smoothness issues and tested the point added to it using the QC Framework ReportGUI with the Esmini viewer. The points seemed to make sense in the issue context, and indeed helped to identify the issue location.

![image](https://github.com/user-attachments/assets/a6583c52-a4ff-470d-bf9d-723b2c756e80)
![image](https://github.com/user-attachments/assets/1a28f526-4cfb-4db4-92b4-4835b1948d14)


**Notes**
- None.