### PR TITLE
Fix road new lane appear issue message to take linkage tag into account

### DIFF
--- a/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
@@ -20,8 +20,9 @@ FLOAT_COMPARISON_THRESHOLD = 1e-6
 def _raise_issue(
     checker_data: models.CheckerData,
     lane: etree._Element,
-    successor_width_zero_lane: etree._Element,
+    width_zero_lane: etree._Element,
     issue_severity: IssueSeverity,
+    linkage_tag: models.LinkageTag,
 ) -> None:
     issue_id = checker_data.result.register_issue(
         checker_bundle_name=constants.BUNDLE_NAME,
@@ -36,15 +37,15 @@ def _raise_issue(
         checker_id=CHECKER_ID,
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
-        description="Lane with successors with width zero.",
+        description=f"Lane with {linkage_tag.value} with width zero.",
     )
 
     checker_data.result.add_xml_location(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=CHECKER_ID,
         issue_id=issue_id,
-        xpath=checker_data.input_file_xml_root.getpath(successor_width_zero_lane),
-        description="Successor lane with width zero.",
+        xpath=checker_data.input_file_xml_root.getpath(width_zero_lane),
+        description=f"{linkage_tag.value.capitalize()} lane with width zero.",
     )
 
 
@@ -92,6 +93,7 @@ def _check_successor_with_width_zero_between_lane_sections(
                     lane,
                     successor_lane,
                     IssueSeverity.ERROR,
+                    models.LinkageTag.SUCCESSOR,
                 )
 
 
@@ -139,6 +141,7 @@ def _check_predecessor_with_width_zero_between_lane_sections(
                     lane,
                     predecessor_lane,
                     IssueSeverity.ERROR,
+                    models.LinkageTag.PREDECESSOR,
                 )
 
 
@@ -340,6 +343,7 @@ def _check_appearing_successor_junction(
                     current_road_lane,
                     connection_lane,
                     IssueSeverity.ERROR,
+                    models.LinkageTag.SUCCESSOR,
                 )
 
 
@@ -423,6 +427,7 @@ def _check_appearing_predecessor_junction(
                     current_road_lane,
                     connection_lane,
                     IssueSeverity.ERROR,
+                    models.LinkageTag.PREDECESSOR,
                 )
 
 


### PR DESCRIPTION
**Description**

This PR fixes the error message to take into account properly the road relation.

**Main changes**

1. [Fix road new lane appear issue message to take linkage tag into account](https://github.com/asam-ev/qc-opendrive/commit/c0e3084de907748dd76e0ea5c8e320636de69eb5)

**How was the PR tested?**

1. Unit-test.
2. Launched the module with some of the `road_new_lane_appear` examples and checked the message. Now it is properly taking into account the relation.


**Notes**
- Closes #101 