### PR TITLE
Lower the required version of xmlschema to 3.3.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -758,4 +758,4 @@ docs = ["Sphinx", "elementpath (>=4.4.0,<5.0.0)", "jinja2", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b77641d76ca1c5c09781e94ff01cf8a04f2f4b2789806a56ea37b743bcb61922"
+content-hash = "3a048b66fad82cdc6da151947aef4285f7d4f4b11af6cc3f2155c1f1d4fb71e7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ numpy = "^1.26.0"
 scipy = "^1.14.0"
 pyclothoids = "^0.1.5"
 transforms3d = "^0.4.2"
-xmlschema = "^3.3.2"
+xmlschema = "^3.3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
**Description**

Lower the required version of xmlschema to 3.3.1. It is to make qc_opendrive compatible with scenariogeneration, [where xmlschema is required to be 3.3.1](https://github.com/pyoscx/scenariogeneration/blob/main/setup.py#L19).

**Main changes**

1. Lower xmlschema to 3.3.1

**How was the PR tested?**

1. First, fix xmlschema to 3.3.1 and run unit-tests. All tests pass. Then relax the range to [3.3.1, ...)

**Notes**
