### PR TITLE
Add the concept of applicable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,13 @@ Contributions of valid and invalid OpenDrive sample files are also welcome. New 
 1. Create a new Python module for each checker.
 2. Specify the following global variables for the Python module
 
-| Variable | Meaning |
-| --- | --- |
-| `CHECKER_ID` | The ID of the checker |
-| `CHECKER_DESCRIPTION` | The description of the checker |
-| `CHECKER_PRECONDITIONS` | A set of other checkers in which if any of them raise an issue, the current checker will be skipped |
-| `RULE_UID` | The rule UID of the rule that the checker will check |
+| Variable | Presence | Meaning |
+| --- | --- | --- |
+| `CHECKER_ID` | Required | The ID of the checker |
+| `CHECKER_DESCRIPTION` | Required | The description of the checker |
+| `CHECKER_PRECONDITIONS` | Required | A set of other checkers in which if any of them raise an issue, the current checker will be skipped |
+| `RULE_UID` | Required | The rule UID of the rule that the checker will check |
+| `LAST_SUPPORTED_VERSION` | Optional | The last supported version of the standard. If the input file has a version higher than the last supported version, the checker will be skipped. Do not define this variable if the checker does not have a last supported version. |
 
 3. Implement the checker logic in the following function:
 

--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ Contributions of valid and invalid OpenDrive sample files are also welcome. New 
 | `CHECKER_DESCRIPTION` | Required | The description of the checker |
 | `CHECKER_PRECONDITIONS` | Required | A set of other checkers in which if any of them raise an issue, the current checker will be skipped |
 | `RULE_UID` | Required | The rule UID of the rule that the checker will check |
-| `LAST_SUPPORTED_VERSION` | Optional | The last supported version of the standard. If the input file has a version higher than the last supported version, the checker will be skipped. Do not define this variable if the checker does not have a last supported version. |
+| `APPLICABLE_VERSION` | Optional | An optional variable to define extra constraints on the applicable version. See details below. |
 
-3. Implement the checker logic in the following function:
+1. Implement the checker logic in the following function:
 
 ```python
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -305,3 +305,41 @@ def run_checks(config: Configuration, result: Result) -> None:
 ```
 
 All the checkers in this checker bundle are implemented in this way. Take a look at some of them before implementing your first checker.
+
+**A note on `APPLICABLE_VERSION`**
+
+The `APPLICABLE_VERSION` variable can be used to define additional constraints on the versions of the input files that a rule supports, in addition to the **definition setting** in the rule UID. It can be specified in the same way as the [Python Version Specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5). For example:
+
+```python
+APPLICABLE_VERSION = "<1.8.0"
+APPLICABLE_VERSION = ">=1.6.0"
+APPLICABLE_VERSION = "<1.8.0,>=1.6.0"
+```
+
+The specification consists of a series of version clauses, separated by commas. The comma is equivalent to a logical "AND" operator: a candidate version must match all given version clauses in order to match the **applicable version** as a whole.
+
+The **applicable version** only supports versions of the form `major.minor.patch`. For example, `1.7.0rc1` is not supported, but `1.7.0` is supported.
+
+The **applicable version** only supports the following comparison operators.
+
+* `<` smaller than **(upper bound)**
+* `<=` smaller or equal than **(upper bound)**
+* `>` greater than **(lower bound)**
+* `>=` greater or equal than **(lower bound)**
+
+The **definition setting** in rule UID and the **applicable version** together define the versions of the input file in which a rule can be applied. For example, let's consider a rule UID for ASAM OpenDRIVE `asam.net:xodr:1.6.0:*`. The **definition setting** in this case is `1.6.0`.
+
+1. If no **applicable version** is specified, a rule will be applied starting from the **definition setting** version, up to the most recent one.
+    * For the example, if the `APPLICABLE_VERSION` variable does not exist, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.6.0`.
+
+2. If the **applicable version** is specified, and defines only **upper bounds**, then the **definition setting** defines the lower bound
+    * For the example, if `APPLICABLE_VERSION = "<1.8.0"`, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0: the internal representation of the version specifier is `>=1.6.0,<1.8.0`.
+
+3. If the **applicable version** is specified, and defines at least one **lower bound**, then the **definition setting** is ignored. Only the **lower bounds** defined in the **applicable version** are taken into account.
+    * For the example, if `APPLICABLE_VERSION = ">=1.5.0"`, then the rule is applied to OpenDRIVE versions 1.5.0, 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.5.0`.
+
+| Case Number | Example Rule            | `APPLICABLE_VERSION` | Internal Representation          | File versions to be checked       |
+|-------------|-------------------------|----------------------|----------------------------------|-----------------------------------|
+| 1           | `asam.net:xodr:1.6.0:*` | `""`                 | `">=1.6.0"`                      | 1.6.0, 1.6.1, 1.7.0, 1.8.0        |
+| 2           | `asam.net:xodr:1.6.0:*` | `"<1.8.0"`             | `">=1.6.0,<1.8.0"`           | 1.6.0, 1.6.1, 1.7.0               |
+| 3           | `asam.net:xodr:1.6.0:*` | `">=1.5.0"`            | `">=1.5.0"` | 1.5.0, 1.6.0, 1.6.1, 1.7.0, 1.8.0 |

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Contributions of valid and invalid OpenDrive sample files are also welcome. New 
 | `CHECKER_DESCRIPTION` | Required | The description of the checker |
 | `CHECKER_PRECONDITIONS` | Required | A set of other checkers in which if any of them raise an issue, the current checker will be skipped |
 | `RULE_UID` | Required | The rule UID of the rule that the checker will check |
-| `APPLICABLE_VERSION` | Optional | An optional variable to define extra constraints on the applicable version. See details below. |
+| `APPLICABLE_VERSIONS` | Optional | An optional variable to define extra constraints on the applicable version. See details below. |
 
 1. Implement the checker logic in the following function:
 
@@ -306,39 +306,39 @@ def run_checks(config: Configuration, result: Result) -> None:
 
 All the checkers in this checker bundle are implemented in this way. Take a look at some of them before implementing your first checker.
 
-**A note on `APPLICABLE_VERSION`**
+**A note on `APPLICABLE_VERSIONS`**
 
-The `APPLICABLE_VERSION` variable can be used to define additional constraints on the versions of the input files that a rule supports, in addition to the **definition setting** in the rule UID. It can be specified in the same way as the [Python Version Specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5). For example:
+The `APPLICABLE_VERSIONS` variable can be used to define additional constraints on the versions of the input files that a rule supports, in addition to the **definition setting** in the rule UID. It can be specified in the same way as the [Python Version Specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5). For example:
 
 ```python
-APPLICABLE_VERSION = "<1.8.0"
-APPLICABLE_VERSION = ">=1.6.0"
-APPLICABLE_VERSION = "<1.8.0,>=1.6.0"
+APPLICABLE_VERSIONS = "<1.8.0"
+APPLICABLE_VERSIONS = ">=1.6.0"
+APPLICABLE_VERSIONS = "<1.8.0,>=1.6.0"
 ```
 
-The specification consists of a series of version clauses, separated by commas. The comma is equivalent to a logical "AND" operator: a candidate version must match all given version clauses in order to match the **applicable version** as a whole.
+The specification consists of a series of version clauses, separated by commas. The comma is equivalent to a logical "AND" operator: a candidate version must match all given version clauses in order to match the **applicable versions** as a whole.
 
-The **applicable version** only supports versions of the form `major.minor.patch`. For example, `1.7.0rc1` is not supported, but `1.7.0` is supported.
+The **applicable versions** only supports versions of in the full semantic form `major.minor.patch`. Elision of `minor` or `patch` elements are not supported. For example, `1.7.0rc1` and `1.7` are not supported, but `1.7.0` is supported.
 
-The **applicable version** only supports the following comparison operators.
+The **applicable versions** only supports the following comparison operators.
 
 * `<` smaller than **(upper bound)**
 * `<=` smaller or equal than **(upper bound)**
 * `>` greater than **(lower bound)**
 * `>=` greater or equal than **(lower bound)**
 
-The **definition setting** in rule UID and the **applicable version** together define the versions of the input file in which a rule can be applied. For example, let's consider a rule UID for ASAM OpenDRIVE `asam.net:xodr:1.6.0:*`. The **definition setting** in this case is `1.6.0`.
+The **definition setting** in rule UID and the **applicable versions** together define the versions of the input file in which a rule can be applied. For example, let's consider a rule UID for ASAM OpenDRIVE `asam.net:xodr:1.6.0:*`. The **definition setting** in this case is `1.6.0`.
 
-1. If no **applicable version** is specified, a rule will be applied starting from the **definition setting** version, up to the most recent one.
-    * For the example, if the `APPLICABLE_VERSION` variable does not exist, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.6.0`.
+1. If no **applicable versions** is specified, a rule will be applied starting from the **definition setting** version, up to the most recent one.
+    * For the example, if the `APPLICABLE_VERSIONS` variable does not exist, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.6.0`.
 
-2. If the **applicable version** is specified, and defines only **upper bounds**, then the **definition setting** defines the lower bound
-    * For the example, if `APPLICABLE_VERSION = "<1.8.0"`, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0: the internal representation of the version specifier is `>=1.6.0,<1.8.0`.
+2. If the **applicable versions** is specified, and defines only **upper bounds**, then the **definition setting** defines the lower bound
+    * For the example, if `APPLICABLE_VERSIONS = "<1.8.0"`, then the rule is applied to OpenDRIVE versions 1.6.0, 1.6.1, 1.7.0: the internal representation of the version specifier is `>=1.6.0,<1.8.0`.
 
-3. If the **applicable version** is specified, and defines at least one **lower bound**, then the **definition setting** is ignored. Only the **lower bounds** defined in the **applicable version** are taken into account.
-    * For the example, if `APPLICABLE_VERSION = ">=1.5.0"`, then the rule is applied to OpenDRIVE versions 1.5.0, 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.5.0`.
+3. If the **applicable versions** is specified, and defines at least one **lower bound**, then the **definition setting** is ignored. Only the **lower bounds** defined in the **applicable versions** are taken into account.
+    * For the example, if `APPLICABLE_VERSIONS = ">=1.5.0"`, then the rule is applied to OpenDRIVE versions 1.5.0, 1.6.0, 1.6.1, 1.7.0, 1.8.0: the internal representation of the version specifier is `>=1.5.0`.
 
-| Case Number | Example Rule            | `APPLICABLE_VERSION` | Internal Representation          | File versions to be checked       |
+| Case Number | Example Rule            | `APPLICABLE_VERSIONS` | Internal Representation          | File versions to be checked       |
 |-------------|-------------------------|----------------------|----------------------------------|-----------------------------------|
 | 1           | `asam.net:xodr:1.6.0:*` | `""`                 | `">=1.6.0"`                      | 1.6.0, 1.6.1, 1.7.0, 1.8.0        |
 | 2           | `asam.net:xodr:1.6.0:*` | `"<1.8.0"`             | `">=1.6.0,<1.8.0"`           | 1.6.0, 1.6.1, 1.7.0               |

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,33 +29,33 @@ pydantic-xml = ">=2.11.0,<3.0.0"
 
 [[package]]
 name = "black"
-version = "24.8.0"
+version = "24.10.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
+    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
+    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
+    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
+    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
+    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
+    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
+    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
 ]
 
 [package.dependencies]
@@ -69,7 +69,7 @@ typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
@@ -100,13 +100,13 @@ files = [
 
 [[package]]
 name = "elementpath"
-version = "4.5.0"
+version = "4.6.0"
 description = "XPath 1.0/2.0/3.0/3.1 parsers and selectors for ElementTree and lxml"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "elementpath-4.5.0-py3-none-any.whl", hash = "sha256:a16438bcc6b2b3069dde204c1e105322378a108b28faea3055d1b294443babea"},
-    {file = "elementpath-4.5.0.tar.gz", hash = "sha256:affdc8de95af1a4c10d1d2ed79c6fa56b59c26c7fce64b73497569e9dea46998"},
+    {file = "elementpath-4.6.0-py3-none-any.whl", hash = "sha256:e578677f19ccc6ff374c4477c687c547ecbaf7b478d98abb951b7b4b45260a17"},
+    {file = "elementpath-4.6.0.tar.gz", hash = "sha256:ba46bf07f66774927727ade55022b6c435fac06b2523cb3cd7689a1884d33468"},
 ]
 
 [package.extras]
@@ -697,6 +697,17 @@ doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.13.1)", "jupytext"
 test = ["Cython", "array-api-strict (>=2.0)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.2"
 description = "A lil' TOML parser"
@@ -734,13 +745,13 @@ files = [
 
 [[package]]
 name = "xmlschema"
-version = "3.4.2"
+version = "3.4.3"
 description = "An XML Schema validator and decoder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "xmlschema-3.4.2-py3-none-any.whl", hash = "sha256:c6b4de5f8aadeb45e74229f09a2129342b446456efc5e5a27388050afdfedec8"},
-    {file = "xmlschema-3.4.2.tar.gz", hash = "sha256:d35023ea504ea46127302d1297b046d023b96fec5fe4b4b690534ea85b5e9bf8"},
+    {file = "xmlschema-3.4.3-py3-none-any.whl", hash = "sha256:eea4e5a1aac041b546ebe7b2eb68eb5eaebf5c5258e573cfc182375676b2e4e3"},
+    {file = "xmlschema-3.4.3.tar.gz", hash = "sha256:0c638dac81c7d6c9da9a8d7544402c48cffe7ee0e13cc47fc0c18794d1395dfb"},
 ]
 
 [package.dependencies]
@@ -754,4 +765,4 @@ docs = ["Sphinx", "elementpath (>=4.4.0,<5.0.0)", "jinja2", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "da96639686a715680bfa09499b7751aebce60067618f09ae60405e034ec0bc77"
+content-hash = "38843d6ec103d3e0f5ff932bb4b9f2ba826d5fdd2cb7aa9858854120aa3d1d7c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ scipy = "^1.14.0"
 pyclothoids = "^0.1.5"
 transforms3d = "^0.4.2"
 xmlschema = "^3.3.1"
+semver = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/qc_opendrive/__init__.py
+++ b/qc_opendrive/__init__.py
@@ -7,3 +7,4 @@
 from . import constants as constants
 from . import checks as checks
 from . import basic_preconditions as basic_preconditions
+from . import version as version

--- a/qc_opendrive/base/utils.py
+++ b/qc_opendrive/base/utils.py
@@ -1757,35 +1757,3 @@ def get_middle_point_xyz_at_height_zero_from_lane_by_s(
 
 def get_s_offset_from_access(access: etree._ElementTree) -> Optional[float]:
     return to_float(access.get("sOffset"))
-
-
-def compare_versions(version1: str, version2: str) -> int:
-    """Compare two version strings like "X.x.x"
-        This function is to avoid comparing version string basing on lexicographical order
-        that could cause problem. E.g.
-        1.10.0 > 1.2.0 but lexicographical comparison of string would return the opposite
-
-    Args:
-        version1 (str): First string to compare
-        version2 (str): Second string to compare
-
-    Returns:
-        int: 1 if version1 is bigger than version2. 0 if the version are the same. -1 otherwise
-    """
-    v1_components = list(map(int, version1.split(".")))
-    v2_components = list(map(int, version2.split(".")))
-
-    # Compare each component until one is greater or they are equal
-    for v1, v2 in zip(v1_components, v2_components):
-        if v1 < v2:
-            return -1
-        elif v1 > v2:
-            return 1
-
-    # If all components are equal, compare based on length
-    if len(v1_components) < len(v2_components):
-        return -1
-    elif len(v1_components) > len(v2_components):
-        return 1
-    else:
-        return 0

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -19,6 +19,7 @@ CHECKER_ID = "check_asam_xodr_junctions_connection_one_connection_element"
 CHECKER_DESCRIPTION = "Each connecting road shall be represented by exactly one element. A connecting road may contain as many lanes as required."
 CHECKER_PRECONDITIONS = basic_preconditions.CHECKER_PRECONDITIONS
 RULE_UID = "asam.net:xodr:1.7.0:junctions.connection.one_connection_element"
+LAST_SUPPORTED_VERSION = "1.7.0"
 
 
 def _check_junctions_connection_one_connection_element(

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -19,7 +19,7 @@ CHECKER_ID = "check_asam_xodr_junctions_connection_one_connection_element"
 CHECKER_DESCRIPTION = "Each connecting road shall be represented by exactly one element. A connecting road may contain as many lanes as required."
 CHECKER_PRECONDITIONS = basic_preconditions.CHECKER_PRECONDITIONS
 RULE_UID = "asam.net:xodr:1.7.0:junctions.connection.one_connection_element"
-LAST_SUPPORTED_VERSION = "1.7.0"
+APPLICABLE_VERSION = "<=1.7.0"
 
 
 def _check_junctions_connection_one_connection_element(

--- a/qc_opendrive/main.py
+++ b/qc_opendrive/main.py
@@ -77,9 +77,7 @@ def check_version(checker: types.ModuleType, checker_data: models.CheckerData) -
     applicable_version = getattr(checker, "APPLICABLE_VERSION", "")
 
     # Check whether applicable version specification is valid
-    if applicable_version and not version.is_valid_version_expression(
-        applicable_version
-    ):
+    if not version.is_valid_version_expression(applicable_version):
         checker_data.result.set_checker_status(
             checker_bundle_name=constants.BUNDLE_NAME,
             checker_id=checker.CHECKER_ID,
@@ -110,14 +108,8 @@ def check_version(checker: types.ModuleType, checker_data: models.CheckerData) -
 
         return False
 
-    match_applicable_version = (
-        version.match(schema_version, applicable_version)
-        if applicable_version
-        else True
-    )
-
     # First, check applicable version
-    if not match_applicable_version:
+    if not version.match(schema_version, applicable_version):
         checker_data.result.set_checker_status(
             checker_bundle_name=constants.BUNDLE_NAME,
             checker_id=checker.CHECKER_ID,

--- a/qc_opendrive/main.py
+++ b/qc_opendrive/main.py
@@ -73,7 +73,7 @@ def execute_checker(
 
         return
 
-    # Checker definition setting. If not satisfied then set status as SKIPPED and return
+    # Check definition setting. If not satisfied then set status as SKIPPED and return
     if required_definition_setting:
         schema_version = checker_data.schema_version
 
@@ -96,6 +96,28 @@ def execute_checker(
                 constants.BUNDLE_NAME,
                 checker.CHECKER_ID,
                 f"Version {schema_version} is lower than definition setting {definition_setting}. Skip the check.",
+            )
+
+            return
+
+    # Check last supported version. If not satisfied then set status as SKIPPED and return
+    if hasattr(checker, "LAST_SUPPORTED_VERSION"):
+        schema_version = checker_data.schema_version
+        if (
+            schema_version is None
+            or utils.compare_versions(schema_version, checker.LAST_SUPPORTED_VERSION)
+            > 0
+        ):
+            checker_data.result.set_checker_status(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=checker.CHECKER_ID,
+                status=StatusType.SKIPPED,
+            )
+
+            checker_data.result.add_checker_summary(
+                constants.BUNDLE_NAME,
+                checker.CHECKER_ID,
+                f"Version {schema_version} is higher than the last supported version {checker.LAST_SUPPORTED_VERSION}. Skip the check.",
             )
 
             return

--- a/qc_opendrive/version.py
+++ b/qc_opendrive/version.py
@@ -22,14 +22,15 @@ _re_remove_spaces = re.compile(r"\s+")
 
 def _get_version_clauses(applicable_versions: str) -> List[str]:
     version_clauses = _re_split_clauses.split(applicable_versions)
-    return [_re_remove_spaces.sub("", vc) for vc in version_clauses]
+    version_clauses = [_re_remove_spaces.sub("", vc) for vc in version_clauses]
+    return [vc for vc in version_clauses if vc != ""]
 
 
-_is_valid_clause_pattern = re.compile(r"^([<>]=?)(\d+)\.(\d+)\.(\d+)$")
+_re_is_valid_clause = re.compile(r"^([<>]=?)(\d+)\.(\d+)\.(\d+)$")
 
 
 def _is_valid_clause(clause: str) -> bool:
-    return bool(_is_valid_clause_pattern.match(clause))
+    return bool(_re_is_valid_clause.match(clause))
 
 
 def is_valid_version_expression(version_expression: str) -> bool:
@@ -51,32 +52,6 @@ def has_lower_bound(applicable_versions: str) -> bool:
             for clause in _get_version_clauses(applicable_versions)
         )
     )
-
-
-def match(version: str, applicable_version: str) -> bool:
-    """
-    Check if the version is valid, given an applicable version.
-
-    Applicable version is comma separated. The comma acts as a logical AND.
-    A candidate version must match all given version clauses in order to match
-    the applicable_version as a whole.
-
-    The validity check follows the concept of Python version specifiers.
-    See: https://packaging.python.org/en/latest/specifications/version-specifiers/#id5
-
-    :param version: The version to be checked.
-    :param applicable_version: Comma separated applicable version.
-    """
-    version_clauses = _get_version_clauses(applicable_version)
-
-    parsed_version = Version.parse(version)
-
-    for clause in version_clauses:
-        is_matched = parsed_version.match(clause)
-        if not is_matched:
-            return False
-
-    return True
 
 
 def match(version: str, applicable_versions: str) -> bool:

--- a/qc_opendrive/version.py
+++ b/qc_opendrive/version.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright 2024, ASAM e.V.
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import re
+from typing import List, Optional
+from semver.version import Version
+
+
+def _is_lower_bound(expression: str) -> bool:
+    pattern = r"^(>=|>)"
+    match = re.match(pattern, expression)
+    if match:
+        return True
+    else:
+        return False
+
+
+def _get_version_clause(applicable_version: str) -> bool:
+    version_clauses = applicable_version.split(",")
+    version_clauses = [clause.replace(" ", "") for clause in version_clauses]
+    return version_clauses
+
+
+def is_valid_version_expression(version_expression: str) -> bool:
+    version_clauses = _get_version_clause(version_expression)
+    pattern = r"^(>=|<=|>|<)(\d+)\.(\d+)\.(\d+)$"
+    for clause in version_clauses:
+        match = re.match(pattern, clause)
+        if not match:
+            return False
+
+    return True
+
+
+def has_lower_bound(applicable_version: str) -> bool:
+    """
+    Check if there is at least one lower bound in an applicable version string.
+    Example:
+        "<1.0.0,>0.0.1" returns True
+        "<1.0.0" returns False
+    """
+    expressions = applicable_version.split(",")
+
+    for expr in expressions:
+        if _is_lower_bound(expr):
+            return True
+
+    return False
+
+
+def match(version: str, applicable_version: str) -> bool:
+    """
+    Check if the version is valid, given an applicable version.
+
+    Applicable version is comma separated. The comma acts as a logical AND.
+    A candidate version must match all given version clauses in order to match
+    the applicable_version as a whole.
+
+    The validity check follows the concept of Python version specifiers.
+    See: https://packaging.python.org/en/latest/specifications/version-specifiers/#id5
+
+    :param version: The version to be checked.
+    :param applicable_version: Comma separated applicable version.
+    """
+    version_clauses = _get_version_clause(applicable_version)
+
+    parsed_version = Version.parse(version)
+
+    for clause in version_clauses:
+        is_matched = parsed_version.match(clause)
+        if not is_matched:
+            return False
+
+    return True

--- a/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_v1_6_0_skipped.xodr
+++ b/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_v1_6_0_skipped.xodr
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="6" name="created by Trian3DBuilder v8.0.1 3c18915702 - opendrive" version="1.00" date="31.10.2024 11:20:49" north="2.83990680783754e+02" south="-2.20362352750963e+02" east="2.89685367564554e+02" west="-2.14667666018475e+02" vendor="TrianGraphics GmbH">
+		<geoReference><![CDATA[+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs]]></geoReference>
+		<offset x="3.57902712032242e+05" y="1.22230713640724e+06" z="0.00000000000000e+00" hdg="0.00000000000000e+00" />
+		<userData code="settings" value=" UseVecIDsFromTrian3D" />
+	</header>
+	<road name="unnamed" length="1.51349505713155e+02" id="19686" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="8.32351677581319e+01" y="8.46848977622576e+01" hdg="4.72568387249930e-01" length="8.85829933854601e+01">
+				<line />
+			</geometry>
+			<geometry s="8.85829933854601e+01" x="1.62109656536195e+02" y="1.25005633583060e+02" hdg="4.72568387249930e-01" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="8.89749117932952e+01" x="1.62458475668391e+02" y="1.25184309741249e+02" hdg="4.75017877298899e-01" length="1.78792006543244e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.06854112447620e+02" x="1.77316187118297e+02" y="1.35062866816064e+02" hdg="6.98507885477955e-01" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.07246030855455e+02" x="1.77615907198458e+02" y="1.35315389745636e+02" hdg="7.00957375526924e-01" length="4.41034748577005e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="1.95064260000000e+01" b="2.54585936499086e-02" c="1.30236023502827e-04" d="-1.32923832012274e-06" />
+			<elevation s="9.79145121204574e+01" a="2.20000000000000e+01" b="1.27313600852305e-02" c="-4.13404283028861e-04" d="3.35594744164197e-06" />
+			<elevation s="1.31349505713155e+02" a="2.20889638355401e+01" b="-3.65815020447030e-03" c="-3.01413746104061e-04" d="1.30955833738607e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="2.80488014364610e+02" id="19687" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.77678624185501e+00" y="3.32720591762336e+02" hdg="5.86983761349644e+00" length="1.68803789190894e+02">
+				<line />
+			</geometry>
+			<geometry s="1.68803789190894e+02" x="1.49810561237566e+02" y="2.64915936726844e+02" hdg="5.86983761349644e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.69195707598729e+02" x="1.50169344020542e+02" y="2.64758219032548e+02" hdg="5.86738812344747e+00" length="5.62491136604964e+01">
+				<arc curvature="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="2.25444821259225e+02" x="1.89825838256569e+02" y="2.26507634218549e+02" hdg="5.16427420269127e+00" length="3.91918407835100e-01">
+				<spiral curvStart="-1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="2.25836739667060e+02" x="1.89996398217278e+02" y="2.26154775526840e+02" hdg="5.16182471264230e+00" length="5.46512746975493e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="3.00000000000000e+00" b="8.65379905323144e-02" c="1.72453615285372e-04" d="-8.65608821463535e-07" />
+			<elevation s="1.97320264428977e+02" a="2.01399990000000e+01" b="5.34869934297411e-02" c="-7.23363170453072e-04" d="3.93324269815227e-06" />
+			<elevation s="2.60488014364610e+02" a="2.16236866143326e+01" b="9.18340341098860e-03" c="1.90401005140676e-03" d="-7.11198378893823e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.84272967117381e+02" id="19688" junction="-1">
+		<link>
+			<predecessor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.21099507245119e+02" y="1.61673622467089e+02" hdg="5.16182735000461e+00" length="7.50036660180319e+01">
+				<line />
+			</geometry>
+			<geometry s="7.50036660180319e+01" x="2.53685581014084e+02" y="9.41184767528903e+01" hdg="5.16182735000461e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="7.53955844258670e+01" x="2.53856141905417e+02" y="9.37656185110100e+01" hdg="5.16427684005358e+00" length="3.12206613965967e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.06616245822464e+02" x="2.72557034161408e+02" y="6.90128834447823e+01" hdg="5.55453510751104e+00" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.07008164230299e+02" x="2.72849859926733e+02" y="6.87523973076604e+01" hdg="5.55698459756001e+00" length="7.72648028870819e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="-3.10490399368509e-03" d="8.84192699320664e-05" />
+			<elevation s="2.00000000000000e+01" a="2.14653925619825e+01" b="-1.80930358289238e-02" c="1.08458018275172e-05" d="-7.41238688583724e-07" />
+			<elevation s="9.10059151241654e+01" a="1.99699990000000e+01" b="-2.77644242311864e-02" c="-1.56688382302166e-04" d="8.41236067269391e-07" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.29553749403376e+02" id="19689" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="3.20291470758151e+02" y="2.59787913762266e+02" hdg="3.61256451554291e+00" length="2.16096847494180e+01">
+				<line />
+			</geometry>
+			<geometry s="2.16096847494180e+01" x="3.01034481565352e+02" y="2.49982464144938e+02" hdg="3.61256451554291e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="2.20016031572531e+01" x="3.00685377616785e+02" y="2.49804345112992e+02" hdg="3.61501400559188e+00" length="2.67111912539670e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="4.87127944112202e+01" x="2.79365644269332e+02" y="2.33918727599550e+02" hdg="3.94890389626647e+00" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="4.91047128190553e+01" x="2.79095117673336e+02" y="2.33635151653318e+02" hdg="3.95135338631544e+00" length="8.04490365843212e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="1.66000000000000e+01" b="9.29293058776317e-02" c="1.05645538879343e-03" d="-2.95564292167162e-05" />
+			<elevation s="3.53571987842366e+01" a="1.99000000000000e+01" b="5.67876421598007e-02" c="-7.06807180851516e-04" d="3.43163113835549e-06" />
+			<elevation s="1.09553749403376e+02" a="2.16240723389326e+01" b="8.57703988634401e-03" c="1.96175346937141e-03" d="-7.25393155510002e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.69307777089555e+01" id="14" junction="26">
+		<link>
+			<predecessor elementType="road" elementId="19689" contactPoint="end" />
+			<successor elementType="road" elementId="19686" contactPoint="end" />
+		</link>
+		<type s="0.00000000000000e+00" type="rural" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.23611692929175e+02" y="1.75380219965009e+02" hdg="3.95135338632433e+00" length="4.22919795806195e+00">
+				<line />
+			</geometry>
+			<geometry s="4.22919795806195e+00" x="2.20694934735482e+02" y="1.72317763923202e+02" hdg="3.95135338633310e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="4.62111636589705e+00" x="2.20424408139545e+02" y="1.72034187976969e+02" hdg="3.94890389628413e+00" length="8.31235016436283e+00">
+				<arc curvature="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.29334665302599e+01" x="2.14375527624914e+02" y="1.66338218451245e+02" hdg="3.84499951922960e+00" length="3.91918407835100e-01">
+				<spiral curvStart="-1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.33253849380950e+01" x="2.14076220312389e+02" y="1.66085206417600e+02" hdg="3.84255002920723e+00" length="3.60539277086055e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+							<predecessor id="1" />
+							<successor id="-1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<predecessor id="-1" />
+							<successor id="1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+		<userData code="CrossingUniqueID" value="26" />
+		<userData code="Predecessor" value="19689 1" />
+		<userData code="Successor" value="19686 1" />
+	</road>
+	<road name="unnamed" length="1.69393845472886e+01" id="65" junction="26">
+		<link>
+			<predecessor elementType="road" elementId="19687" contactPoint="end" />
+			<successor elementType="road" elementId="19688" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="rural" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.13740047379048e+02" y="1.76930787974503e+02" hdg="5.16182598276526e+00" length="1.69393845472886e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+							<predecessor id="1" />
+							<successor id="1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<predecessor id="-1" />
+							<successor id="-1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+		<userData code="CrossingUniqueID" value="26" />
+		<userData code="Predecessor" value="19687 1" />
+		<userData code="Successor" value="19688 0" />
+	</road>
+	<junction name="unnamed" id="26">
+		<connection id="0" incomingRoad="19689" connectingRoad="14" contactPoint="start">
+			<laneLink from="-1" to="-1" />
+		</connection>
+		<connection id="1" incomingRoad="19686" connectingRoad="14" contactPoint="end">
+			<laneLink from="-1" to="1" />
+		</connection>
+		<connection id="2" incomingRoad="19687" connectingRoad="65" contactPoint="start">
+			<laneLink from="-1" to="-1" />
+		</connection>
+		<connection id="3" incomingRoad="19688" connectingRoad="65" contactPoint="end">
+			<laneLink from="1" to="1" />
+		</connection>
+	</junction>
+</OpenDRIVE>

--- a/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_v1_8_0_valid.xodr
+++ b/tests/data/junctions_connection_one_connection_element/junctions_connection_one_connection_element_v1_8_0_valid.xodr
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenDRIVE>
+	<header revMajor="1" revMinor="8" name="created by Trian3DBuilder v8.0.1 3c18915702 - opendrive" version="1.00" date="31.10.2024 11:20:49" north="2.83990680783754e+02" south="-2.20362352750963e+02" east="2.89685367564554e+02" west="-2.14667666018475e+02" vendor="TrianGraphics GmbH">
+		<geoReference><![CDATA[+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs]]></geoReference>
+		<offset x="3.57902712032242e+05" y="1.22230713640724e+06" z="0.00000000000000e+00" hdg="0.00000000000000e+00" />
+		<userData code="settings" value=" UseVecIDsFromTrian3D" />
+	</header>
+	<road name="unnamed" length="1.51349505713155e+02" id="19686" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="8.32351677581319e+01" y="8.46848977622576e+01" hdg="4.72568387249930e-01" length="8.85829933854601e+01">
+				<line />
+			</geometry>
+			<geometry s="8.85829933854601e+01" x="1.62109656536195e+02" y="1.25005633583060e+02" hdg="4.72568387249930e-01" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="8.89749117932952e+01" x="1.62458475668391e+02" y="1.25184309741249e+02" hdg="4.75017877298899e-01" length="1.78792006543244e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.06854112447620e+02" x="1.77316187118297e+02" y="1.35062866816064e+02" hdg="6.98507885477955e-01" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.07246030855455e+02" x="1.77615907198458e+02" y="1.35315389745636e+02" hdg="7.00957375526924e-01" length="4.41034748577005e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="1.95064260000000e+01" b="2.54585936499086e-02" c="1.30236023502827e-04" d="-1.32923832012274e-06" />
+			<elevation s="9.79145121204574e+01" a="2.20000000000000e+01" b="1.27313600852305e-02" c="-4.13404283028861e-04" d="3.35594744164197e-06" />
+			<elevation s="1.31349505713155e+02" a="2.20889638355401e+01" b="-3.65815020447030e-03" c="-3.01413746104061e-04" d="1.30955833738607e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="2.80488014364610e+02" id="19687" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="-4.77678624185501e+00" y="3.32720591762336e+02" hdg="5.86983761349644e+00" length="1.68803789190894e+02">
+				<line />
+			</geometry>
+			<geometry s="1.68803789190894e+02" x="1.49810561237566e+02" y="2.64915936726844e+02" hdg="5.86983761349644e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.69195707598729e+02" x="1.50169344020542e+02" y="2.64758219032548e+02" hdg="5.86738812344747e+00" length="5.62491136604964e+01">
+				<arc curvature="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="2.25444821259225e+02" x="1.89825838256569e+02" y="2.26507634218549e+02" hdg="5.16427420269127e+00" length="3.91918407835100e-01">
+				<spiral curvStart="-1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="2.25836739667060e+02" x="1.89996398217278e+02" y="2.26154775526840e+02" hdg="5.16182471264230e+00" length="5.46512746975493e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="3.00000000000000e+00" b="8.65379905323144e-02" c="1.72453615285372e-04" d="-8.65608821463535e-07" />
+			<elevation s="1.97320264428977e+02" a="2.01399990000000e+01" b="5.34869934297411e-02" c="-7.23363170453072e-04" d="3.93324269815227e-06" />
+			<elevation s="2.60488014364610e+02" a="2.16236866143326e+01" b="9.18340341098860e-03" c="1.90401005140676e-03" d="-7.11198378893823e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.84272967117381e+02" id="19688" junction="-1">
+		<link>
+			<predecessor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.21099507245119e+02" y="1.61673622467089e+02" hdg="5.16182735000461e+00" length="7.50036660180319e+01">
+				<line />
+			</geometry>
+			<geometry s="7.50036660180319e+01" x="2.53685581014084e+02" y="9.41184767528903e+01" hdg="5.16182735000461e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="7.53955844258670e+01" x="2.53856141905417e+02" y="9.37656185110100e+01" hdg="5.16427684005358e+00" length="3.12206613965967e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.06616245822464e+02" x="2.72557034161408e+02" y="6.90128834447823e+01" hdg="5.55453510751104e+00" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.07008164230299e+02" x="2.72849859926733e+02" y="6.87523973076604e+01" hdg="5.55698459756001e+00" length="7.72648028870819e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="-3.10490399368509e-03" d="8.84192699320664e-05" />
+			<elevation s="2.00000000000000e+01" a="2.14653925619825e+01" b="-1.80930358289238e-02" c="1.08458018275172e-05" d="-7.41238688583724e-07" />
+			<elevation s="9.10059151241654e+01" a="1.99699990000000e+01" b="-2.77644242311864e-02" c="-1.56688382302166e-04" d="8.41236067269391e-07" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.29553749403376e+02" id="19689" junction="-1">
+		<link>
+			<successor elementType="junction" elementId="26" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="motorway" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="3.20291470758151e+02" y="2.59787913762266e+02" hdg="3.61256451554291e+00" length="2.16096847494180e+01">
+				<line />
+			</geometry>
+			<geometry s="2.16096847494180e+01" x="3.01034481565352e+02" y="2.49982464144938e+02" hdg="3.61256451554291e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="2.20016031572531e+01" x="3.00685377616785e+02" y="2.49804345112992e+02" hdg="3.61501400559188e+00" length="2.67111912539670e+01">
+				<arc curvature="1.25000000000000e-02" />
+			</geometry>
+			<geometry s="4.87127944112202e+01" x="2.79365644269332e+02" y="2.33918727599550e+02" hdg="3.94890389626647e+00" length="3.91918407835100e-01">
+				<spiral curvStart="1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="4.91047128190553e+01" x="2.79095117673336e+02" y="2.33635151653318e+02" hdg="3.95135338631544e+00" length="8.04490365843212e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="1.66000000000000e+01" b="9.29293058776317e-02" c="1.05645538879343e-03" d="-2.95564292167162e-05" />
+			<elevation s="3.53571987842366e+01" a="1.99000000000000e+01" b="5.67876421598007e-02" c="-7.06807180851516e-04" d="3.43163113835549e-06" />
+			<elevation s="1.09553749403376e+02" a="2.16240723389326e+01" b="8.57703988634401e-03" c="1.96175346937141e-03" d="-7.25393155510002e-05" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="broken" weight="standard" color="standard" material="standard" width="2.00000002980232e-01" laneChange="both">
+							<type name="broken" width="2.00000002980232e-01">
+								<line length="3.00000000000000e+00" space="6.00000000000000e+00" tOffset="0.00000000000000e+00" sOffset="0.00000000000000e+00" width="2.00000002980232e-01" color="standard" />
+							</type>
+						</roadMark>
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="solid" weight="standard" color="standard" material="standard" width="1.19999997317791e-01" laneChange="none" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+					<lane id="-2" type="shoulder">
+						<width sOffset="0.00000000000000e+00" a="7.50000000000000e-01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+	</road>
+	<road name="unnamed" length="1.69307777089555e+01" id="14" junction="26">
+		<link>
+			<predecessor elementType="road" elementId="19689" contactPoint="end" />
+			<successor elementType="road" elementId="19686" contactPoint="end" />
+		</link>
+		<type s="0.00000000000000e+00" type="rural" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.23611692929175e+02" y="1.75380219965009e+02" hdg="3.95135338632433e+00" length="4.22919795806195e+00">
+				<line />
+			</geometry>
+			<geometry s="4.22919795806195e+00" x="2.20694934735482e+02" y="1.72317763923202e+02" hdg="3.95135338633310e+00" length="3.91918407835100e-01">
+				<spiral curvStart="0.00000000000000e+00" curvEnd="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="4.62111636589705e+00" x="2.20424408139545e+02" y="1.72034187976969e+02" hdg="3.94890389628413e+00" length="8.31235016436283e+00">
+				<arc curvature="-1.25000000000000e-02" />
+			</geometry>
+			<geometry s="1.29334665302599e+01" x="2.14375527624914e+02" y="1.66338218451245e+02" hdg="3.84499951922960e+00" length="3.91918407835100e-01">
+				<spiral curvStart="-1.25000000000000e-02" curvEnd="0.00000000000000e+00" />
+			</geometry>
+			<geometry s="1.33253849380950e+01" x="2.14076220312389e+02" y="1.66085206417600e+02" hdg="3.84255002920723e+00" length="3.60539277086055e+00">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+							<predecessor id="1" />
+							<successor id="-1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<predecessor id="-1" />
+							<successor id="1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+		<userData code="CrossingUniqueID" value="26" />
+		<userData code="Predecessor" value="19689 1" />
+		<userData code="Successor" value="19686 1" />
+	</road>
+	<road name="unnamed" length="1.69393845472886e+01" id="65" junction="26">
+		<link>
+			<predecessor elementType="road" elementId="19687" contactPoint="end" />
+			<successor elementType="road" elementId="19688" contactPoint="start" />
+		</link>
+		<type s="0.00000000000000e+00" type="rural" />
+		<planView>
+			<geometry s="0.00000000000000e+00" x="2.13740047379048e+02" y="1.76930787974503e+02" hdg="5.16182598276526e+00" length="1.69393845472886e+01">
+				<line />
+			</geometry>
+		</planView>
+		<elevationProfile>
+			<elevation s="0.00000000000000e+00" a="2.20000000000000e+01" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+		</elevationProfile>
+		<lateralProfile />
+		<lanes>
+			<laneSection s="0.00000000000000e+00">
+				<left>
+					<lane id="1" type="driving">
+						<link>
+							<predecessor id="1" />
+							<successor id="1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</left>
+				<center>
+					<lane id="0" type="driving">
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+					</lane>
+				</center>
+				<right>
+					<lane id="-1" type="driving">
+						<link>
+							<predecessor id="-1" />
+							<successor id="-1" />
+						</link>
+						<width sOffset="0.00000000000000e+00" a="3.25000000000000e+00" b="0.00000000000000e+00" c="0.00000000000000e+00" d="0.00000000000000e+00" />
+						<roadMark sOffset="0.00000000000000e+00" type="none" weight="standard" color="standard" material="standard" laneChange="both" />
+						<speed sOffset="0.00000000000000e+00" max="1.38888888888889e+01" unit="m/s" />
+						<height sOffset="0.00000000000000e+00" inner="0.00000000000000e+00" outer="0.00000000000000e+00" />
+					</lane>
+				</right>
+			</laneSection>
+		</lanes>
+		<userData code="CrossingUniqueID" value="26" />
+		<userData code="Predecessor" value="19687 1" />
+		<userData code="Successor" value="19688 0" />
+	</road>
+	<junction name="unnamed" id="26">
+		<connection id="0" incomingRoad="19689" connectingRoad="14" contactPoint="start">
+			<laneLink from="-1" to="-1" />
+		</connection>
+		<connection id="1" incomingRoad="19686" connectingRoad="14" contactPoint="end">
+			<laneLink from="-1" to="1" />
+		</connection>
+		<connection id="2" incomingRoad="19687" connectingRoad="65" contactPoint="start">
+			<laneLink from="-1" to="-1" />
+		</connection>
+		<connection id="3" incomingRoad="19688" connectingRoad="65" contactPoint="end">
+			<laneLink from="1" to="1" />
+		</connection>
+	</junction>
+</OpenDRIVE>

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -496,9 +496,10 @@ def test_junctions_connection_one_connection_element(
     "target_file,issue_count,issue_xpath",
     [
         ("v1_8_0_valid", 0, []),
+        ("v1_6_0_skipped", 0, []),
     ],
 )
-def test_junctions_connection_one_connection_element_last_supported_version(
+def test_junctions_connection_one_connection_element_applicable_version(
     target_file: str,
     issue_count: int,
     issue_xpath: List[str],

--- a/tests/test_semantic_checks.py
+++ b/tests/test_semantic_checks.py
@@ -495,6 +495,32 @@ def test_junctions_connection_one_connection_element(
 @pytest.mark.parametrize(
     "target_file,issue_count,issue_xpath",
     [
+        ("v1_8_0_valid", 0, []),
+    ],
+)
+def test_junctions_connection_one_connection_element_last_supported_version(
+    target_file: str,
+    issue_count: int,
+    issue_xpath: List[str],
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/junctions_connection_one_connection_element/"
+    target_file_name = f"junctions_connection_one_connection_element_{target_file}.xodr"
+    rule_uid = "asam.net:xodr:1.7.0:junctions.connection.one_connection_element"
+
+    target_file_path = os.path.join(base_path, target_file_name)
+    create_test_config(target_file_path)
+    launch_main(monkeypatch)
+    check_skipped(
+        rule_uid,
+        semantic.junctions_connection_one_connection_element.CHECKER_ID,
+    )
+    cleanup_files()
+
+
+@pytest.mark.parametrize(
+    "target_file,issue_count,issue_xpath",
+    [
         ("valid", 0, []),
         (
             "invalid",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright 2024, ASAM e.V.
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+from qc_opendrive import version as qc_version
+
+
+@pytest.mark.parametrize(
+    "applicable_version,has_lower_bound",
+    [
+        (">1.0.0", True),
+        (">1.0.0,<2.0.0", True),
+        (">1.0.0,<=2.0.0", True),
+        (">=1.0.0", True),
+        (">=1.0.0,<2.0.0", True),
+        (">=1.0.0,<=2.0.0", True),
+        (">=1.0.0,>=1.0.1,<=2.0.0", True),
+        (">=1.0.0,<=1.0.1,<=2.0.0", True),
+        ("<=2.0.0", False),
+        ("<2.0.0", False),
+        ("<=2.0.0,<=3.0.0", False),
+        ("<2.0.0,<3.0.0", False),
+    ],
+)
+def test_has_lower_bound(applicable_version: str, has_lower_bound: bool) -> None:
+    assert qc_version.has_lower_bound(applicable_version) == has_lower_bound
+
+
+@pytest.mark.parametrize(
+    "version,applicable_version,match",
+    [
+        ("1.7.0", ">=1.7.0", True),
+        ("1.7.0", "<=1.7.0", True),
+        ("1.7.0", ">1.7.0", False),
+        ("1.7.0", "<1.7.0", False),
+        ("1.7.0", "<1.7.0,<1.8.0", False),
+        ("1.7.0", ">1.7.0,>1.6.0", False),
+        ("1.7.0", ">=1.7.0,>1.6.0", True),
+        ("1.7.0", ">=1.7.0,>1.8.0", False),
+        ("1.7.0", "<=1.7.0,>1.8.0", False),
+        ("1.7.0", "<=1.7.0,<1.8.0", True),
+        ("1.7.0", "<=1.7.0,<1.6.0", False),
+    ],
+)
+def test_match(version: str, applicable_version: str, match: bool) -> None:
+    assert qc_version.match(version, applicable_version) == match
+
+
+@pytest.mark.parametrize(
+    "version_expression,is_valid",
+    [
+        ("1.7.0", False),
+        (">1.7.0", True),
+        (">=1.7.0", True),
+        ("<1.7.0", True),
+        ("<=1.7.0", True),
+        ("==1.7.0", False),
+        ("!=1.7.0", False),
+        ("<1.7", False),
+    ],
+)
+def test_is_valid_version_expression(version_expression: str, is_valid: bool) -> None:
+    assert qc_version.is_valid_version_expression(version_expression) == is_valid

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -23,6 +23,7 @@ from qc_opendrive import version as qc_version
         ("<2.0.0", False),
         ("<=2.0.0,<=3.0.0", False),
         ("<2.0.0,<3.0.0", False),
+        ("", False),
     ],
 )
 def test_has_lower_bound(applicable_version: str, has_lower_bound: bool) -> None:
@@ -43,6 +44,7 @@ def test_has_lower_bound(applicable_version: str, has_lower_bound: bool) -> None
         ("1.7.0", "<=1.7.0,>1.8.0", False),
         ("1.7.0", "<=1.7.0,<1.8.0", True),
         ("1.7.0", "<=1.7.0,<1.6.0", False),
+        ("1.7.0", "<=1.7.0,<1.8", False),
     ],
 )
 def test_match(version: str, applicable_version: str, match: bool) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -45,6 +45,7 @@ def test_has_lower_bound(applicable_version: str, has_lower_bound: bool) -> None
         ("1.7.0", "<=1.7.0,<1.8.0", True),
         ("1.7.0", "<=1.7.0,<1.6.0", False),
         ("1.7.0", "<=1.7.0,<1.8", False),
+        ("1.7.0", "", True),
     ],
 )
 def test_match(version: str, applicable_version: str, match: bool) -> None:
@@ -62,6 +63,7 @@ def test_match(version: str, applicable_version: str, match: bool) -> None:
         ("==1.7.0", False),
         ("!=1.7.0", False),
         ("<1.7", False),
+        ("", True),
     ],
 )
 def test_is_valid_version_expression(version_expression: str, is_valid: bool) -> None:


### PR DESCRIPTION
**Description**

Add the concept of "last supported version" as it was not supported in the rule uid. Address #117.

**Main changes**

1. Add the concept of "last supported version". Checker will be skipped if the input file version is higher than the last supported version.
2. Specify the last supported version of `asam.net:xodr:1.7.0:junctions.connection.one_connection_element` as `1.7.0`. This is the only implemented rule that has the last supported version.

**How was the PR tested?**

1. Unit-test

**Notes**
Related issue: #117 