### PR TITLE
Add file location from XML elements to the issues in checks

### DIFF
--- a/qc_opendrive/checks/basic/fileheader_is_present.py
+++ b/qc_opendrive/checks/basic/fileheader_is_present.py
@@ -55,4 +55,5 @@ def check_rule(checker_data: models.CheckerData) -> None:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(root),
             description=f"No child element header",
+            lines=root.sourceline,
         )

--- a/qc_opendrive/checks/basic/fileheader_is_present.py
+++ b/qc_opendrive/checks/basic/fileheader_is_present.py
@@ -55,5 +55,13 @@ def check_rule(checker_data: models.CheckerData) -> None:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(root),
             description=f"No child element header",
-            lines=root.sourceline,
+        )
+
+        checker_data.result.add_file_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            issue_id=issue_id,
+            row=root.sourceline,
+            column=0,
+            description="No child element header",
         )

--- a/qc_opendrive/checks/basic/root_tag_is_opendrive.py
+++ b/qc_opendrive/checks/basic/root_tag_is_opendrive.py
@@ -50,5 +50,13 @@ def check_rule(checker_data: models.CheckerData) -> bool:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(root),
             description=f"Root is not OpenDRIVE",
-            lines=root.sourceline,
+        )
+
+        checker_data.result.add_file_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            issue_id=issue_id,
+            row=root.sourceline,
+            column=0,
+            description="Root is not OpenDRIVE",
         )

--- a/qc_opendrive/checks/basic/root_tag_is_opendrive.py
+++ b/qc_opendrive/checks/basic/root_tag_is_opendrive.py
@@ -50,4 +50,5 @@ def check_rule(checker_data: models.CheckerData) -> bool:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(root),
             description=f"Root is not OpenDRIVE",
+            lines=root.sourceline,
         )

--- a/qc_opendrive/checks/basic/version_is_defined.py
+++ b/qc_opendrive/checks/basic/version_is_defined.py
@@ -100,4 +100,5 @@ def check_rule(checker_data: models.CheckerData) -> bool:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(file_header_tag),
             description=f"Header tag has invalid or missing version info",
+            lines=file_header_tag.sourceline,
         )

--- a/qc_opendrive/checks/basic/version_is_defined.py
+++ b/qc_opendrive/checks/basic/version_is_defined.py
@@ -100,5 +100,13 @@ def check_rule(checker_data: models.CheckerData) -> bool:
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(file_header_tag),
             description=f"Header tag has invalid or missing version info",
-            lines=file_header_tag.sourceline,
+        )
+
+        checker_data.result.add_file_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            issue_id=issue_id,
+            row=file_header_tag.sourceline,
+            column=0,
+            description="Header tag has invalid or missing version info",
         )

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_arclength_range.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_arclength_range.py
@@ -64,7 +64,15 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
-                    lines=geometry.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=geometry.sourceline,
+                    column=0,
+                    description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_arclength_range.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_arclength_range.py
@@ -64,6 +64,7 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
+                    lines=geometry.sourceline,
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_length_match.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_length_match.py
@@ -63,6 +63,7 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
+                    lines=geometry.sourceline,
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_length_match.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_length_match.py
@@ -63,7 +63,15 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
-                    lines=geometry.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=geometry.sourceline,
+                    column=0,
+                    description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
@@ -63,6 +63,7 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
+                    lines=geometry.sourceline,
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
+++ b/qc_opendrive/checks/geometry/road_geometry_parampoly3_normalized_range.py
@@ -63,7 +63,15 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(geometry),
                     description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
-                    lines=geometry.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=geometry.sourceline,
+                    column=0,
+                    description=f"Length does not match the actual curve length. The estimated absolute error from numerical integration is {estimated_error}",
                 )
 
                 s_coordinate = utils.get_s_from_geometry(geometry)

--- a/qc_opendrive/checks/geometry/road_lane_border_overlap_with_inner_lanes.py
+++ b/qc_opendrive/checks/geometry/road_lane_border_overlap_with_inner_lanes.py
@@ -130,7 +130,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(left_lane),
         description=f"Outer lane border intersects or stays within inner lane border.",
-        lines=left_lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=left_lane.sourceline,
+        column=0,
+        description=f"Outer lane border intersects or stays within inner lane border.",
     )
 
     checker_data.result.add_xml_location(
@@ -139,7 +147,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(right_lane),
         description=f"Outer lane border intersects or stays within inner lane border.",
-        lines=right_lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=right_lane.sourceline,
+        column=0,
+        description=f"Outer lane border intersects or stays within inner lane border.",
     )
 
     s_section = utils.get_s_from_lane_section(lane_section_with_length.lane_section)

--- a/qc_opendrive/checks/geometry/road_lane_border_overlap_with_inner_lanes.py
+++ b/qc_opendrive/checks/geometry/road_lane_border_overlap_with_inner_lanes.py
@@ -130,6 +130,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(left_lane),
         description=f"Outer lane border intersects or stays within inner lane border.",
+        lines=left_lane.sourceline,
     )
 
     checker_data.result.add_xml_location(
@@ -138,6 +139,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(right_lane),
         description=f"Outer lane border intersects or stays within inner lane border.",
+        lines=right_lane.sourceline,
     )
 
     s_section = utils.get_s_from_lane_section(lane_section_with_length.lane_section)

--- a/qc_opendrive/checks/performance/performance_avoid_redundant_info.py
+++ b/qc_opendrive/checks/performance/performance_avoid_redundant_info.py
@@ -46,7 +46,15 @@ def _check_road_superelevations(
                     current_superelevation.xml_element
                 ),
                 description=f"Redundant superelevation declaration.",
-                lines=current_superelevation.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_superelevation.xml_element.sourceline,
+                column=0,
+                description=f"Redundant superelevation declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -57,7 +65,15 @@ def _check_road_superelevations(
                     next_superelevation.xml_element
                 ),
                 description=f"Redundant superelevation declaration.",
-                lines=next_superelevation.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_superelevation.xml_element.sourceline,
+                column=0,
+                description=f"Redundant superelevation declaration.",
             )
 
             inertial_point = utils.get_point_xyz_from_road_reference_line(
@@ -99,7 +115,15 @@ def _check_road_elevations(
                     current_elevation.xml_element
                 ),
                 description=f"Redundant elevation declaration.",
-                lines=current_elevation.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_elevation.xml_element.sourceline,
+                column=0,
+                description=f"Redundant superelevation declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -110,7 +134,15 @@ def _check_road_elevations(
                     next_elevation.xml_element
                 ),
                 description=f"Redundant elevation declaration.",
-                lines=next_elevation.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_elevation.xml_element.sourceline,
+                column=0,
+                description=f"Redundant elevation declaration.",
             )
 
             inertial_point = utils.get_point_xyz_from_road_reference_line(
@@ -152,7 +184,15 @@ def _check_lane_offsets(
                     current_lane_offset.xml_element
                 ),
                 description=f"Redundant lane offset declaration.",
-                lines=current_lane_offset.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_lane_offset.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane offset declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -163,7 +203,15 @@ def _check_lane_offsets(
                     next_lane_offset.xml_element
                 ),
                 description=f"Redundant lane offset declaration.",
-                lines=next_lane_offset.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_lane_offset.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane offset declaration.",
             )
 
             s = next_lane_offset.s_offset
@@ -218,7 +266,15 @@ def _check_road_plan_view(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(current_geometry),
                 description=f"Redundant line geometry declaration.",
-                lines=current_geometry.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_geometry.sourceline,
+                column=0,
+                description=f"Redundant line geometry declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -227,7 +283,15 @@ def _check_road_plan_view(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_geometry),
                 description=f"Redundant line geometry declaration.",
-                lines=next_geometry.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_geometry.sourceline,
+                column=0,
+                description=f"Redundant line geometry declaration.",
             )
 
             s_offset = utils.get_s_from_geometry(next_geometry)
@@ -274,7 +338,15 @@ def _check_lane_widths(
                     current_width.xml_element
                 ),
                 description=f"Redundant lane width declaration.",
-                lines=current_width.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_width.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane width declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -283,7 +355,15 @@ def _check_lane_widths(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_width.xml_element),
                 description=f"Redundant lane width declaration.",
-                lines=next_width.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_width.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane width declaration.",
             )
 
             s_section = utils.get_s_from_lane_section(lane_section)
@@ -336,7 +416,15 @@ def _check_lane_borders(
                     current_border.xml_element
                 ),
                 description=f"Redundant lane border declaration.",
-                lines=current_border.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=current_border.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane border declaration.",
             )
 
             checker_data.result.add_xml_location(
@@ -345,7 +433,15 @@ def _check_lane_borders(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_border.xml_element),
                 description=f"Redundant lane border declaration.",
-                lines=next_border.xml_element.sourceline,
+            )
+
+            checker_data.result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=next_border.xml_element.sourceline,
+                column=0,
+                description=f"Redundant lane border declaration.",
             )
 
             s_section = utils.get_s_from_lane_section(lane_section)

--- a/qc_opendrive/checks/performance/performance_avoid_redundant_info.py
+++ b/qc_opendrive/checks/performance/performance_avoid_redundant_info.py
@@ -46,6 +46,7 @@ def _check_road_superelevations(
                     current_superelevation.xml_element
                 ),
                 description=f"Redundant superelevation declaration.",
+                lines=current_superelevation.xml_element.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -56,6 +57,7 @@ def _check_road_superelevations(
                     next_superelevation.xml_element
                 ),
                 description=f"Redundant superelevation declaration.",
+                lines=next_superelevation.xml_element.sourceline,
             )
 
             inertial_point = utils.get_point_xyz_from_road_reference_line(
@@ -97,6 +99,7 @@ def _check_road_elevations(
                     current_elevation.xml_element
                 ),
                 description=f"Redundant elevation declaration.",
+                lines=current_elevation.xml_element.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -107,6 +110,7 @@ def _check_road_elevations(
                     next_elevation.xml_element
                 ),
                 description=f"Redundant elevation declaration.",
+                lines=next_elevation.xml_element.sourceline,
             )
 
             inertial_point = utils.get_point_xyz_from_road_reference_line(
@@ -148,6 +152,7 @@ def _check_lane_offsets(
                     current_lane_offset.xml_element
                 ),
                 description=f"Redundant lane offset declaration.",
+                lines=current_lane_offset.xml_element.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -158,6 +163,7 @@ def _check_lane_offsets(
                     next_lane_offset.xml_element
                 ),
                 description=f"Redundant lane offset declaration.",
+                lines=next_lane_offset.xml_element.sourceline,
             )
 
             s = next_lane_offset.s_offset
@@ -212,6 +218,7 @@ def _check_road_plan_view(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(current_geometry),
                 description=f"Redundant line geometry declaration.",
+                lines=current_geometry.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -220,6 +227,7 @@ def _check_road_plan_view(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_geometry),
                 description=f"Redundant line geometry declaration.",
+                lines=next_geometry.sourceline,
             )
 
             s_offset = utils.get_s_from_geometry(next_geometry)
@@ -266,6 +274,7 @@ def _check_lane_widths(
                     current_width.xml_element
                 ),
                 description=f"Redundant lane width declaration.",
+                lines=current_width.xml_element.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -274,6 +283,7 @@ def _check_lane_widths(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_width.xml_element),
                 description=f"Redundant lane width declaration.",
+                lines=next_width.xml_element.sourceline,
             )
 
             s_section = utils.get_s_from_lane_section(lane_section)
@@ -326,6 +336,7 @@ def _check_lane_borders(
                     current_border.xml_element
                 ),
                 description=f"Redundant lane border declaration.",
+                lines=current_border.xml_element.sourceline,
             )
 
             checker_data.result.add_xml_location(
@@ -334,6 +345,7 @@ def _check_lane_borders(
                 issue_id=issue_id,
                 xpath=checker_data.input_file_xml_root.getpath(next_border.xml_element),
                 description=f"Redundant lane border declaration.",
+                lines=next_border.xml_element.sourceline,
             )
 
             s_section = utils.get_s_from_lane_section(lane_section)

--- a/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
@@ -51,7 +51,15 @@ def _check_junctions_connection_connect_road_no_incoming_road(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connection),
                     description="Connection with connecting road found as incoming road.",
-                    lines=connection.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=connection.sourceline,
+                    column=0,
+                    description=f"Connection with connecting road found as incoming road.",
                 )
 
                 successor_junction_id = utils.get_linked_junction_id(

--- a/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_connect_road_no_incoming_road.py
@@ -51,6 +51,7 @@ def _check_junctions_connection_connect_road_no_incoming_road(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connection),
                     description="Connection with connecting road found as incoming road.",
+                    lines=connection.sourceline,
                 )
 
                 successor_junction_id = utils.get_linked_junction_id(

--- a/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
@@ -38,7 +38,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(connection),
         description=f"Contact point 'end' not used on successor road connection.",
-        lines=connection.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=connection.sourceline,
+        column=0,
+        description=f"Contact point 'end' not used on successor road connection.",
     )
 
     inertial_point = utils.get_end_point_xyz_from_road_reference_line(connection_road)

--- a/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_end_opposite_linkage.py
@@ -38,6 +38,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(connection),
         description=f"Contact point 'end' not used on successor road connection.",
+        lines=connection.sourceline,
     )
 
     inertial_point = utils.get_end_point_xyz_from_road_reference_line(connection_road)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -66,6 +66,7 @@ def _check_junctions_connection_one_connection_element(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connection),
                     description="Connection with reused connecting road id.",
+                    lines=connection.sourceline,
                 )
 
             connecting_road = road_id_map.get(connecting_road_id)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_connection_element.py
@@ -66,7 +66,15 @@ def _check_junctions_connection_one_connection_element(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connection),
                     description="Connection with reused connecting road id.",
-                    lines=connection.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=connection.sourceline,
+                    column=0,
+                    description=f"Connection with reused connecting road id.",
                 )
 
             connecting_road = road_id_map.get(connecting_road_id)

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -44,7 +44,15 @@ def _raise_lane_linkage_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane_link),
         description=f"Lane link in opposite direction.",
-        lines=lane_link.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=lane_link.sourceline,
+        column=0,
+        description=f"Lane link in opposite direction.",
     )
 
     s = None
@@ -563,7 +571,15 @@ def _check_junctions_connection_one_link_to_incoming(
                         issue_id=issue_id,
                         xpath=checker_data.input_file_xml_root.getpath(connection),
                         description=f"Connection with reused (incoming_road_id, connecting_road_id) = ({incoming_road_id}, {connecting_road_id}) pair.",
-                        lines=connection.sourceline,
+                    )
+
+                    checker_data.result.add_file_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=CHECKER_ID,
+                        issue_id=issue_id,
+                        row=connection.sourceline,
+                        column=0,
+                        description=f"Connection with reused (incoming_road_id, connecting_road_id) = ({incoming_road_id}, {connecting_road_id}) pair.",
                     )
 
                 has_start_contact_point = False

--- a/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_one_link_to_incoming.py
@@ -44,6 +44,7 @@ def _raise_lane_linkage_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane_link),
         description=f"Lane link in opposite direction.",
+        lines=lane_link.sourceline,
     )
 
     s = None
@@ -562,6 +563,7 @@ def _check_junctions_connection_one_link_to_incoming(
                         issue_id=issue_id,
                         xpath=checker_data.input_file_xml_root.getpath(connection),
                         description=f"Connection with reused (incoming_road_id, connecting_road_id) = ({incoming_road_id}, {connecting_road_id}) pair.",
+                        lines=connection.sourceline,
                     )
 
                 has_start_contact_point = False

--- a/qc_opendrive/checks/semantic/junctions_connection_start_along_linkage.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_start_along_linkage.py
@@ -38,6 +38,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(connection),
         description=f"Contact point 'start' not used on predecessor road connection.",
+        lines=connection.sourceline,
     )
 
     inertial_point = utils.get_start_point_xyz_from_road_reference_line(connection_road)

--- a/qc_opendrive/checks/semantic/junctions_connection_start_along_linkage.py
+++ b/qc_opendrive/checks/semantic/junctions_connection_start_along_linkage.py
@@ -38,7 +38,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(connection),
         description=f"Contact point 'start' not used on predecessor road connection.",
-        lines=connection.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=connection.sourceline,
+        column=0,
+        description=f"Contact point 'start' not used on predecessor road connection.",
     )
 
     inertial_point = utils.get_start_point_xyz_from_road_reference_line(connection_road)

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -84,6 +84,7 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                                 issue_id=issue_id,
                                 xpath=path,
                                 description=f"First encounter of {current_rule} having {previous_rule} before.",
+                                lines=access.sourceline,
                             )
 
                             if s_section is None:

--- a/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
+++ b/qc_opendrive/checks/semantic/road_lane_access_no_mix_of_deny_or_allow.py
@@ -84,7 +84,15 @@ def _check_all_roads(checker_data: models.CheckerData) -> None:
                                 issue_id=issue_id,
                                 xpath=path,
                                 description=f"First encounter of {current_rule} having {previous_rule} before.",
-                                lines=access.sourceline,
+                            )
+
+                            checker_data.result.add_file_location(
+                                checker_bundle_name=constants.BUNDLE_NAME,
+                                checker_id=CHECKER_ID,
+                                issue_id=issue_id,
+                                row=access.sourceline,
+                                column=0,
+                                description=f"First encounter of {current_rule} having {previous_rule} before.",
                             )
 
                             if s_section is None:

--- a/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
+++ b/qc_opendrive/checks/semantic/road_lane_level_true_one_side.py
@@ -64,7 +64,15 @@ def _check_true_level_on_side(
                 issue_id=issue_id,
                 xpath=path,
                 description=f"Lane id {index} @level=False where previous lane id @level=True.",
-                lines=lane.sourceline,
+            )
+
+            result.add_file_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                issue_id=issue_id,
+                row=lane.sourceline,
+                column=0,
+                description=f"Lane id {index} @level=False where previous lane id @level=True.",
             )
 
             s_section = utils.get_s_from_lane_section(
@@ -170,7 +178,15 @@ def _check_level_change_between_lane_sections(
             issue_id=issue_id,
             xpath=warning,
             description="Lane levels are not the same in two consecutive lane sections",
-            lines=warning_linenr,
+        )
+
+        result.add_file_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            issue_id=issue_id,
+            row=warning_linenr,
+            column=0,
+            description="Lane levels are not the same in two consecutive lane sections",
         )
 
 
@@ -235,7 +251,15 @@ def _check_level_change_linkage_roads(
                     issue_id=issue_id,
                     xpath=root.getpath(lane),
                     description="Lane levels are not the same between two connected roads.",
-                    lines=lane.sourceline,
+                )
+
+                result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=lane.sourceline,
+                    column=0,
+                    description=f"Lane levels are not the same between two connected roads.",
                 )
 
                 result.add_xml_location(
@@ -244,7 +268,15 @@ def _check_level_change_linkage_roads(
                     issue_id=issue_id,
                     xpath=root.getpath(other_lane),
                     description="Lane levels are not the same between two connected roads.",
-                    lines=other_lane.sourceline,
+                )
+
+                result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=other_lane.sourceline,
+                    column=0,
+                    description=f"Lane levels are not the same between two connected roads.",
                 )
 
                 s = None
@@ -414,7 +446,15 @@ def _check_level_among_junctions(
                         issue_id=issue_id,
                         xpath=checker_data.input_file_xml_root.getpath(incoming_lane),
                         description="Lane levels are not the same between incoming road and junction.",
-                        lines=incoming_lane.sourceline,
+                    )
+
+                    checker_data.result.add_file_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=CHECKER_ID,
+                        issue_id=issue_id,
+                        row=incoming_lane.sourceline,
+                        column=0,
+                        description=f"Lane levels are not the same between incoming road and junction.",
                     )
 
                     checker_data.result.add_xml_location(
@@ -423,7 +463,15 @@ def _check_level_among_junctions(
                         issue_id=issue_id,
                         xpath=checker_data.input_file_xml_root.getpath(connection_lane),
                         description="Lane levels are not the same between incoming road and junction.",
-                        lines=connection_lane.sourceline,
+                    )
+
+                    checker_data.result.add_file_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=CHECKER_ID,
+                        issue_id=issue_id,
+                        row=connection_lane.sourceline,
+                        column=0,
+                        description=f"Lane levels are not the same between incoming road and junction.",
                     )
 
 

--- a/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
@@ -64,7 +64,15 @@ def _check_two_lane_sections_one_direction(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connecting_lane),
                     description="Missing lane link.",
-                    lines=connecting_lane.sourceline,
+                )
+
+                checker_data.result.add_file_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=CHECKER_ID,
+                    issue_id=issue_id,
+                    row=connecting_lane.sourceline,
+                    column=0,
+                    description=f"Missing lane link.",
                 )
 
 

--- a/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_lanes_across_lane_sections.py
@@ -64,6 +64,7 @@ def _check_two_lane_sections_one_direction(
                     issue_id=issue_id,
                     xpath=checker_data.input_file_xml_root.getpath(connecting_lane),
                     description="Missing lane link.",
+                    lines=connecting_lane.sourceline,
                 )
 
 

--- a/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
@@ -44,7 +44,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description=f"Lane with {linkage_tag.value} with width zero.",
-        lines=lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=lane.sourceline,
+        column=0,
+        description=f"Lane with {linkage_tag.value} with width zero.",
     )
 
     checker_data.result.add_xml_location(
@@ -53,7 +61,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(width_zero_lane),
         description=f"{linkage_tag.value.capitalize()} lane with width zero.",
-        lines=width_zero_lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=width_zero_lane.sourceline,
+        column=0,
+        description=f"{linkage_tag.value.capitalize()} lane with width zero.",
     )
 
 

--- a/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_new_lane_appear.py
@@ -44,6 +44,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description=f"Lane with {linkage_tag.value} with width zero.",
+        lines=lane.sourceline,
     )
 
     checker_data.result.add_xml_location(
@@ -52,6 +53,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(width_zero_lane),
         description=f"{linkage_tag.value.capitalize()} lane with width zero.",
+        lines=width_zero_lane.sourceline,
     )
 
 

--- a/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_end.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_end.py
@@ -44,6 +44,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description="Lane with width zero and successors.",
+        lines=lane.sourceline,
     )
 
     s_section = utils.get_s_from_lane_section(lane_section_with_length.lane_section)

--- a/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_end.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_end.py
@@ -44,7 +44,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description="Lane with width zero and successors.",
-        lines=lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=lane.sourceline,
+        column=0,
+        description=f"Lane with width zero and successors.",
     )
 
     s_section = utils.get_s_from_lane_section(lane_section_with_length.lane_section)

--- a/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_start.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_start.py
@@ -44,7 +44,15 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description="Lane with width zero and predecessors.",
-        lines=lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=lane.sourceline,
+        column=0,
+        description=f"Lane with width zero and predecessors.",
     )
 
     s = utils.get_s_from_lane_section(lane_section)

--- a/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_start.py
+++ b/qc_opendrive/checks/semantic/road_lane_link_zero_width_at_start.py
@@ -44,6 +44,7 @@ def _raise_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(lane),
         description="Lane with width zero and predecessors.",
+        lines=lane.sourceline,
     )
 
     s = utils.get_s_from_lane_section(lane_section)

--- a/qc_opendrive/checks/semantic/road_linkage_is_junction_needed.py
+++ b/qc_opendrive/checks/semantic/road_linkage_is_junction_needed.py
@@ -43,6 +43,7 @@ def _raise_road_linkage_is_junction_needed_issue(
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(element),
             description=f"Road cannot have ambiguous {linkage_tag.value}, a junction is needed.",
+            lines=element.sourceline,
         )
 
     if problematic_road is not None:

--- a/qc_opendrive/checks/semantic/road_linkage_is_junction_needed.py
+++ b/qc_opendrive/checks/semantic/road_linkage_is_junction_needed.py
@@ -43,7 +43,15 @@ def _raise_road_linkage_is_junction_needed_issue(
             issue_id=issue_id,
             xpath=checker_data.input_file_xml_root.getpath(element),
             description=f"Road cannot have ambiguous {linkage_tag.value}, a junction is needed.",
-            lines=element.sourceline,
+        )
+
+        checker_data.result.add_file_location(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            issue_id=issue_id,
+            row=element.sourceline,
+            column=0,
+            description=f"Road cannot have ambiguous {linkage_tag.value}, a junction is needed.",
         )
 
     if problematic_road is not None:

--- a/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
+++ b/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
@@ -62,6 +62,7 @@ def _raise_geometry_gap_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(previous_geometry),
         description=f"First geometry element",
+        lines=previous_geometry.sourceline,
     )
     checker_data.result.add_xml_location(
         checker_bundle_name=constants.BUNDLE_NAME,
@@ -69,6 +70,7 @@ def _raise_geometry_gap_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(geometry),
         description=f"Second geometry element",
+        lines=geometry.sourceline,
     )
 
     if inertial_point is not None:
@@ -120,6 +122,7 @@ def _raise_lane_linkage_gap_issue(
         issue_id=issue_id,
         xpath=issue_xpaths[0],
         description=f"First lane element",
+        lines=previous_lane.sourceline,
     )
     checker_data.result.add_xml_location(
         checker_bundle_name=constants.BUNDLE_NAME,
@@ -127,6 +130,7 @@ def _raise_lane_linkage_gap_issue(
         issue_id=issue_id,
         xpath=issue_xpaths[1],
         description=f"Next lane element",
+        lines=current_lane.sourceline,
     )
 
     if inertial_point is not None:

--- a/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
+++ b/qc_opendrive/checks/smoothness/lane_smoothness_contact_point_no_horizontal_gaps.py
@@ -62,15 +62,32 @@ def _raise_geometry_gap_issue(
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(previous_geometry),
         description=f"First geometry element",
-        lines=previous_geometry.sourceline,
     )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=previous_geometry.sourceline,
+        column=0,
+        description=f"First geometry element",
+    )
+
     checker_data.result.add_xml_location(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=CHECKER_ID,
         issue_id=issue_id,
         xpath=checker_data.input_file_xml_root.getpath(geometry),
         description=f"Second geometry element",
-        lines=geometry.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=geometry.sourceline,
+        column=0,
+        description=f"Second geometry element",
     )
 
     if inertial_point is not None:
@@ -122,15 +139,32 @@ def _raise_lane_linkage_gap_issue(
         issue_id=issue_id,
         xpath=issue_xpaths[0],
         description=f"First lane element",
-        lines=previous_lane.sourceline,
     )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=previous_lane.sourceline,
+        column=0,
+        description=f"First lane element",
+    )
+
     checker_data.result.add_xml_location(
         checker_bundle_name=constants.BUNDLE_NAME,
         checker_id=CHECKER_ID,
         issue_id=issue_id,
         xpath=issue_xpaths[1],
         description=f"Next lane element",
-        lines=current_lane.sourceline,
+    )
+
+    checker_data.result.add_file_location(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        issue_id=issue_id,
+        row=current_lane.sourceline,
+        column=0,
+        description=f"Next lane element",
     )
 
     if inertial_point is not None:


### PR DESCRIPTION
**Description**

Added also the file location of the XML elements to issues, so that result file contains this information without calling the result pooling before.

Belongs to discussion in qc-baselib-py PR: https://github.com/asam-ev/qc-baselib-py/pull/51

**How was the PR tested?**

1. pytests successful
