### PR TITLE
Run black via poetry in pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
     hooks:
       - id: black
         name: black
-        entry: black
+        entry: poetry run black
         language: system
         types: [python]


### PR DESCRIPTION
This is the preferred way, as it ensures that the right virtual environment is active, see other qc repos.

