### PR TITLE
Update to OpenDRIVE 1.8.1 schema for 1.8.0

### DIFF
--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Core.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Core.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Railroad.xsd"/>
@@ -37,10 +37,6 @@ See www.asam.net/license.html for further details.
         </xs:complexType>
         <xs:key name="k_junctionId">
             <xs:selector xpath="junction"/>
-            <xs:field xpath="@id"/>
-        </xs:key>
-        <xs:key name="k_junction_connectionId">
-            <xs:selector xpath="connection"/>
             <xs:field xpath="@id"/>
         </xs:key>
         <xs:keyref name="r_junction_connection_incomingRoad" refer="k_roadId">
@@ -233,9 +229,9 @@ See www.asam.net/license.html for further details.
         <xs:sequence>
             <!--For compatibility with XSD 1.0 the next line is commented out: - ->
             <!- - <xs:group ref="g_additionalData" minOccurs="0" maxOccurs="unbounded"/> - ->
-            <!- - 
-				To ensure backward compatibility the "additionalData" is applied to each 
-				complex type explicitly to comply with the sequence order of earlier OpenDRIVE versions. 
+            <!- -
+				To ensure backward compatibility the "additionalData" is applied to each
+				complex type explicitly to comply with the sequence order of earlier OpenDRIVE versions.
 				Thus the extension according to the UML is implemented (only) formaly.-->
         </xs:sequence>
     </xs:complexType>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Junction.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Junction.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Core.xsd"/>
@@ -117,8 +117,8 @@ See www.asam.net/license.html for further details.
         <xs:complexContent>
             <xs:extension base="_OpenDriveElement">
                 <xs:sequence>
-                    <!--To ensure backward compatibility the associations of t_junction are applied to each 
-				 child class complex type explicitly to comply with the sequence order of earlier OpenDRIVE versions. 
+                    <!--To ensure backward compatibility the associations of t_junction are applied to each
+				 child class complex type explicitly to comply with the sequence order of earlier OpenDRIVE versions.
 				Thus the extension according to the UML is implemented (only) formaly: - ->
 					<!- -<xs:element maxOccurs="unbounded" minOccurs="0" name="priority" type="t_junction_priority"/>- ->
 					<!- -<xs:element maxOccurs="unbounded" minOccurs="0" name="controller" type="t_junction_controller"/>- ->
@@ -259,6 +259,7 @@ See www.asam.net/license.html for further details.
                         <xs:documentation>Common junctions are of type "default". If the attribute is not specified, the junction type is "default". This attribute is mandatory for all other junction types.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="count(connection/@id) = count(distinct-values(connection/@id))"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -509,6 +510,7 @@ See www.asam.net/license.html for further details.
                         <xs:documentation>Common junctions are of type "default". If the attribute is not specified, the junction type is "default". This attribute is mandatory for all other junction types.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="count(connection/@id) = count(distinct-values(connection/@id))"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -595,12 +597,12 @@ See www.asam.net/license.html for further details.
                 <xs:sequence>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
                 </xs:sequence>
-                <xs:attribute name="high" type="xs:string" use="optional">
+                <xs:attribute name="high" type="xs:string" use="required">
                     <xs:annotation>
                         <xs:documentation>ID of the prioritized road</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="low" type="xs:string" use="optional">
+                <xs:attribute name="low" type="xs:string" use="required">
                     <xs:annotation>
                         <xs:documentation>ID of the road with lower priority</xs:documentation>
                     </xs:annotation>
@@ -684,6 +686,7 @@ See www.asam.net/license.html for further details.
                         <xs:documentation>Common junctions are of type "default". If the attribute is not specified, the junction type is "default". This attribute is mandatory for all other junction types.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="count(connection/@id) = count(distinct-values(connection/@id))"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Lane.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Lane.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Core.xsd"/>
@@ -347,6 +347,7 @@ Lanes contain a series of lane section elements that define the characteristics 
                     <xs:element maxOccurs="unbounded" minOccurs="1" name="laneSection" type="t_road_lanes_laneSection"/>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
                 </xs:sequence>
+                <xs:assert test="if (count(laneOffset) &gt; 0) then count(laneSection//border) = 0 else true()"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -863,7 +864,7 @@ Lane width and lane border elements are mutually exclusive within the same lane 
     </xs:complexType>
     <xs:complexType name="t_road_lanes_laneSection_lr_lane_height">
         <xs:annotation>
-            <xs:documentation>Lane heights elevate lanes along the h-coordinate within a lane section independent from the road elevation. 
+            <xs:documentation>Lane heights elevate lanes along the h-coordinate within a lane section independent from the road elevation.
 Lane height is used to implement small-scale elevation such as raising pedestrian walkways. Lane height is specified as offset from the road (including elevation, superelevation, shape, cross section surface) in h-direction.</xs:documentation>
         </xs:annotation>
         <xs:complexContent>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Object.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Object.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Core.xsd"/>
@@ -220,7 +220,16 @@ If the crosswalk is defined as an object only, it will not be used for pedestria
         <xs:complexContent>
             <xs:extension base="_OpenDriveElement">
                 <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="object" type="t_road_objects_object"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="object" type="t_road_objects_object">
+                        <xs:keyref name="r_road_objects_object_borders_border_outlineRef" refer="k_road_objects_object_outlines_outlineId">
+                            <xs:selector xpath="road/objects/object/borders/border"/>
+                            <xs:field xpath="@outlineId"/>
+                        </xs:keyref>
+                        <xs:key name="k_road_objects_object_outlines_outlineId">
+                            <xs:selector xpath="road/objects/object/outlines/outline | road/objects/object/outline"/>
+                            <xs:field xpath="@id"/>
+                        </xs:key>
+                    </xs:element>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="objectReference" type="t_road_objects_objectReference"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tunnel" type="t_road_objects_tunnel"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="bridge" type="t_road_objects_bridge"/>
@@ -301,7 +310,7 @@ There are two ways to describe the bounding box of objects.
                 </xs:attribute>
                 <xs:attribute name="height" type="t_grEqZero" use="optional">
                     <xs:annotation>
-                        <xs:documentation>Height of the object's bounding box. 
+                        <xs:documentation>Height of the object's bounding box.
 @height is defined in the local coordinate system u/v along the z-axis</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -385,6 +394,19 @@ There are two ways to describe the bounding box of objects.
                         <xs:documentation>z-offset of object's origin relative to the elevation of the road reference line</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="not(@radius or @width or @length) or (@radius and not(@width or @length)) or  (@width and @length and not(@radius))"/>
+                <xs:assert test="if (@type = 'barrier') then (not(@radius) and not(marking) and not(border) and not(material) and not(surface) and not(parkingSpace) and not(skeleton) and (not(repeat/@distance) or repeat/@distance = 0)) else true()"/>
+                <xs:assert test="if (@type = 'building') then (not(marking) and not(border) and not(material) and not(surface) and not(parkingSpace) and not(skeleton) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'crosswalk') then (not(skeleton) and not(border) and not(parkingSpace) and not(@radius) and (not(repeat/@distance) or repeat/@distance != 0)) else true()"/>
+                <xs:assert test="if (@type = 'gantry') then (not(@radius) and not(marking) and not(border) and not(material) and not(surface) and not(parkingSpace) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'obstacle') then (not(skeleton) and not(marking) and not(border) and not(material) and not(surface) and not(parkingSpace) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'parkingSpace') then (not(@radius) and not(skeleton) and not(border) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'pole') then (not(border) and not(parkingSpace) and not(material) and not(marking) and not(surface) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'roadMark') then (not(@radius) and not(skeleton) and not(border) and not(parkingSpace) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'roadSurface') then (not(skeleton) and not(border) and not(parkingSpace) and not(marking) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'trafficIsland') then (not(skeleton) and not(surface) and not(parkingSpace)) else true()"/>
+                <xs:assert test="if (@type = 'tree') then (not(material) and not(surface) and not(border) and not(parkingSpace) and not(marking) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
+                <xs:assert test="if (@type = 'vegetation') then (not(skeleton) and not(material) and not(surface) and not(border) and not(parkingSpace) and not(marking) and (not(repeat/@distance) or repeat/@distance &gt; 0)) else true()"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -432,6 +454,7 @@ Different border types are available.</xs:documentation>
                         <xs:documentation>Border width</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="if (@useCompleteOutline) then not(cornerReference) else count(cornerReference) gt 1"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -578,9 +601,9 @@ ASAM OpenDRIVE 1.4 outline definitions (without &lt;outlines&gt; parent element)
         <xs:complexContent>
             <xs:extension base="_OpenDriveElement">
                 <xs:sequence>
-                    <xs:choice maxOccurs="1" minOccurs="0">
-                        <xs:element maxOccurs="unbounded" minOccurs="1" name="cornerRoad" type="t_road_objects_object_outlines_outline_cornerRoad"/>
-                        <xs:element maxOccurs="unbounded" minOccurs="1" name="cornerLocal" type="t_road_objects_object_outlines_outline_cornerLocal"/>
+                    <xs:choice maxOccurs="1" minOccurs="1">
+                        <xs:element maxOccurs="unbounded" minOccurs="2" name="cornerRoad" type="t_road_objects_object_outlines_outline_cornerRoad"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="2" name="cornerLocal" type="t_road_objects_object_outlines_outline_cornerLocal"/>
                     </xs:choice>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
                 </xs:sequence>
@@ -812,13 +835,13 @@ If this value is zero, then the object is treated like a continuous feature, for
     </xs:complexType>
     <xs:complexType name="t_road_objects_object_skeleton_polyline">
         <xs:annotation>
-            <xs:documentation>Defines a series of points relative to the road reference line. 
+            <xs:documentation>Defines a series of points relative to the road reference line.
 An &lt;polyline&gt; element shall be followed by either two or more &lt;vertexRoad&gt; elements or by two or more &lt;vertexLocal&gt; elements.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:choice maxOccurs="1" minOccurs="0">
-                <xs:element maxOccurs="unbounded" minOccurs="1" name="vertexRoad" type="t_road_objects_object_skeleton_polyline_vertexRoad"/>
-                <xs:element maxOccurs="unbounded" minOccurs="1" name="vertexLocal" type="t_road_objects_object_skeleton_polyline_vertexLocal"/>
+            <xs:choice maxOccurs="1" minOccurs="1">
+                <xs:element maxOccurs="unbounded" minOccurs="2" name="vertexRoad" type="t_road_objects_object_skeleton_polyline_vertexRoad"/>
+                <xs:element maxOccurs="unbounded" minOccurs="2" name="vertexLocal" type="t_road_objects_object_skeleton_polyline_vertexLocal"/>
             </xs:choice>
             <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
         </xs:sequence>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Railroad.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Railroad.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Junction.xsd"/>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Road.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Road.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Junction.xsd"/>
@@ -220,6 +220,7 @@ ASAM OpenDRIVE roads may be roads in the real road network or artificial road ne
                     <xs:element maxOccurs="1" minOccurs="0" name="crossSectionSurface" type="t_road_lateralProfile_crossSectionSurface"/>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
                 </xs:sequence>
+                <xs:assert test="not(exists(crossSectionSurface)) or (not(exists(superelevation)) and not(exists(shape)))"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -715,7 +716,7 @@ Positive curvature: left curve (counter-clockwise motion) Negative curvature: ri
                 </xs:attribute>
                 <xs:attribute name="curvStart" type="xs:double" use="required">
                     <xs:annotation>
-                        <xs:documentation>Curvature at the start of the element. 
+                        <xs:documentation>Curvature at the start of the element.
 Positive curvature: left curve (counter-clockwise motion) Negative curvature: right curve (clockwise motion)</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -777,7 +778,7 @@ Positive curvature: left curve (counter-clockwise motion) Negative curvature: ri
                 </xs:attribute>
                 <xs:attribute name="sOffset" type="xs:double" use="optional">
                     <xs:annotation>
-                        <xs:documentation>s-offset between CRG center line and reference line of the road 
+                        <xs:documentation>s-offset between CRG center line and reference line of the road
 (default = 0.0)</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/qc_opendrive/schema/1.8.1/OpenDRIVE_Signal.xsd
+++ b/qc_opendrive/schema/1.8.1/OpenDRIVE_Signal.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--ASAM OpenDRIVE V1.8.0
 
-© by ASAM e.V., 2023
+© by ASAM e.V., 2024
 
 ASAM OpenDRIVE defines a file format for the precise analytical description of road networks
 
 
-Any use is limited to the scope described in the ASAM license terms. 
-This file is distributable in accordance with the ASAM license terms. 
+Any use is limited to the scope described in the ASAM license terms.
+This file is distributable in accordance with the ASAM license terms.
 See www.asam.net/license.html for further details.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="OpenDRIVE_Object.xsd"/>
@@ -265,8 +265,6 @@ The &lt;signals&gt; element is the container for all signals along a road.</xs:d
                         <xs:element maxOccurs="1" minOccurs="1" name="positionRoad" type="t_road_signals_signal_positionRoad"/>
                     </xs:choice>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="staticBoard" type="t_road_signals_staticBoard"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="vmsBoard" type="t_road_signals_vmsBoard"/>
                     <xs:element maxOccurs="1" minOccurs="0" name="semantics" type="t_signals_semantics"/>
                 </xs:sequence>
                 <xs:attribute name="country" type="e_countryCode" use="optional">
@@ -340,7 +338,7 @@ Heading offset of the signal (relative to road reference line, if orientation is
                 </xs:attribute>
                 <xs:attribute name="type" type="xs:string" use="required">
                     <xs:annotation>
-                        <xs:documentation>Type identifier according to country code 
+                        <xs:documentation>Type identifier according to country code
 or "-1" / "none". See extra document.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -379,7 +377,7 @@ or "-1" / "none". See extra document.</xs:documentation>
                 </xs:attribute>
                 <xs:attribute name="type" type="xs:string" use="optional">
                     <xs:annotation>
-                        <xs:documentation>Type of the dependency, 
+                        <xs:documentation>Type of the dependency,
 Free text, depending on application</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -496,7 +494,7 @@ Free text, depending on application</xs:documentation>
                 </xs:attribute>
                 <xs:attribute name="type" type="xs:string" use="optional">
                     <xs:annotation>
-                        <xs:documentation>Type of the linkage 
+                        <xs:documentation>Type of the linkage
 Free text, depending on application</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -509,7 +507,10 @@ Free text, depending on application</xs:documentation>
         </xs:annotation>
         <xs:complexContent>
             <xs:extension base="t_road_signals_signal">
-                <xs:sequence/>
+                <xs:sequence>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="staticBoard" type="t_road_signals_staticBoard"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="vmsBoard" type="t_road_signals_vmsBoard"/>
+                </xs:sequence>
                 <xs:attribute name="s" type="t_grEqZero" use="optional">
                     <xs:annotation>
                         <xs:documentation>s-coordinate</xs:documentation>
@@ -525,6 +526,7 @@ Free text, depending on application</xs:documentation>
                         <xs:documentation>z-offset of signal's origin relative to the elevation of the road reference line</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:assert test="not(@type = 'multiBoard') or (@type = 'multiBoard' and @dynamic = true() and count(./vmsBoard) gt 0 and count(./staticBoard) gt 0)"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -757,11 +759,11 @@ Variable message boards are switched off if they are not specified in ASAM OpenS
         <xs:complexContent>
             <xs:extension base="_OpenDriveElement">
                 <xs:sequence>
-                    <xs:element maxOccurs="1" minOccurs="1" name="type" type="e_signals_semantics_speed"/>
-                    <xs:element maxOccurs="1" minOccurs="1" name="unit" type="e_unitSpeed"/>
-                    <xs:element maxOccurs="1" minOccurs="1" name="value" type="xs:double"/>
                     <xs:group maxOccurs="unbounded" minOccurs="0" ref="g_additionalData"/>
                 </xs:sequence>
+                <xs:attribute name="type" type="e_signals_semantics_speed" use="optional"/>
+                <xs:attribute name="unit" type="e_unitSpeed" use="optional"/>
+                <xs:attribute name="value" type="xs:double" use="optional"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/qc_opendrive/schema/schema_files.py
+++ b/qc_opendrive/schema/schema_files.py
@@ -12,5 +12,5 @@ SCHEMA_FILES = {
     "1.5.0": "1.5/OpenDRIVE_1.5M.xsd",
     "1.6.0": "1.6.1/opendrive_16_core.xsd",
     "1.7.0": "1.7.0/opendrive_17_core.xsd",
-    "1.8.0": "1.8.0/OpenDRIVE_Core.xsd",
+    "1.8.0": "1.8.1/OpenDRIVE_Core.xsd",
 }


### PR DESCRIPTION
This is based on the released schemas, with encoding and line-ending fixes due to release breakage in the 1.8.1 deliverable.
