### PR TITLE
Handle missing optional road links in contact-point check

### DIFF
--- a/qc_opendrive/checks/geometry/road_geometry_contact_point.py
+++ b/qc_opendrive/checks/geometry/road_geometry_contact_point.py
@@ -103,10 +103,18 @@ def _check_junctions_connection_lane_follow_direction(
         if utils.to_int(road.get("junction")) == 1:
             continue
 
-        road_start = (road.find("link").find("predecessor"),
-                      utils.get_start_point_xyz_from_road_reference_line(road))
-        road_end = (road.find("link").find("successor"),
-                    utils.get_end_point_xyz_from_road_reference_line(road))
+        road_link = road.find("link")
+        if road_link is None:
+            continue
+
+        road_start = (
+            road_link.find("predecessor"),
+            utils.get_start_point_xyz_from_road_reference_line(road),
+        )
+        road_end = (
+            road_link.find("successor"),
+            utils.get_end_point_xyz_from_road_reference_line(road),
+        )
 
         for road_side in (road_start, road_end):
             xcessor_contact_point_xyz_with_issue = _xcessor_contact_point_has_issue(*road_side, road_id_map)

--- a/tests/data/road_geometry_contact_point/valid_missing_link.xodr
+++ b/tests/data/road_geometry_contact_point/valid_missing_link.xodr
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenDRIVE>
+  <header date="2025-02-20T09:09:29" name="straight_road_roadmarks" revMajor="1" revMinor="8" north="0.0" south="0.0" east="0.0" west="0.0" vendor="Vector Informatik GmbH"/>
+  <road id="0" junction="-1" length="1500" name="straight road">
+    <type s="0" type="motorway"/>
+    <planView>
+      <geometry hdg="0" length="1500" s="0" x="0" y="0">
+        <line/>
+      </geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="2" level="false" type="border">
+            <width a="0.3" b="0" c="0" d="0" sOffset="0"/>
+            <roadMark color="standard" laneChange="both" sOffset="0" type="none" weight="standard"/>
+          </lane>
+          <lane id="1" level="false" type="driving">
+            <width a="3.5" b="0" c="0" d="0" sOffset="0"/>
+            <roadMark color="standard" laneChange="both" sOffset="0" type="solid" weight="standard" width="0.12"/>
+          </lane>
+        </left>
+        <center>
+          <lane id="0" level="false" type="none">
+            <roadMark color="standard" laneChange="both" sOffset="0" type="broken" weight="standard" width="0.12"/>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" level="false" type="driving">
+            <width a="3.5" b="0" c="0" d="0" sOffset="0"/>
+            <roadMark color="standard" laneChange="both" sOffset="0" type="solid" weight="standard" width="0.12"/>
+          </lane>
+          <lane id="-2" level="false" type="border">
+            <width a="0.3" b="0" c="0" d="0" sOffset="0"/>
+            <roadMark color="standard" laneChange="both" sOffset="0" type="none" weight="standard"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>

--- a/tests/test_geometry_checks.py
+++ b/tests/test_geometry_checks.py
@@ -226,6 +226,11 @@ def test_road_geometry_param_poly3_normalized_range(
             [],
         ),
         (
+            "valid_missing_link",
+            0,
+            [],
+        ),
+        (
             "invalid",
             2,
             [


### PR DESCRIPTION
## Summary
- handle schema-valid roads that omit the optional `<link>` element in `check_asam_xodr_road_geometry_contact_point`
- add a regression fixture for a one-road OpenDRIVE 1.8 file without `<link>`
- keep the check behavior unchanged for roads that do provide predecessor/successor linkage

## Root cause
`qc_opendrive/checks/geometry/road_geometry_contact_point.py` dereferenced `road.find("link").find(...)` unconditionally.

However, the bundled OpenDRIVE 1.8.1 schema declares `<road><link>` as optional (`minOccurs="0"`), so a standalone road without linkage is schema-valid. On such inputs, the checker raised an internal `AttributeError: 'NoneType' object has no attribute 'find'` instead of simply skipping the contact-point rule for that road.

## Reproduction
Before this change:
- a schema-valid single-road OpenDRIVE file with no `<link>` caused `check_asam_xodr_road_geometry_contact_point` to fail internally
- the same happened on the real-world `StraightRoad_NCAP_Roadmarks.xodr` repro from the HD-map asset pipeline

After this change:
- roads without `<link>` are skipped by this rule
- the regression fixture passes
- the real repro completes this checker with status `completed`

## Validation
- `python -m pytest tests/test_geometry_checks.py -k road_geometry_contact_point -q`
- direct repro against `StraightRoad_NCAP_Roadmarks.xodr` using the checker config path: contact-point checker status changed from `error` to `completed`
